### PR TITLE
Environment variables

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -143,6 +143,7 @@ _TeamCity*
 _NCrunch_*
 .*crunch*.local.xml
 nCrunchTemp_*
+.ncrunchsolution
 
 # MightyMoose
 *.mm.*

--- a/CliFx.Tests/CliApplicationBuilderTests.cs
+++ b/CliFx.Tests/CliApplicationBuilderTests.cs
@@ -1,8 +1,9 @@
-﻿using System;
-using System.IO;
-using CliFx.Services;
+﻿using CliFx.Services;
+using CliFx.Tests.Stubs;
 using CliFx.Tests.TestCommands;
 using NUnit.Framework;
+using System;
+using System.IO;
 
 namespace CliFx.Tests
 {
@@ -20,8 +21,8 @@ namespace CliFx.Tests
             builder
                 .AddCommand(typeof(HelloWorldDefaultCommand))
                 .AddCommandsFrom(typeof(HelloWorldDefaultCommand).Assembly)
-                .AddCommands(new[] {typeof(HelloWorldDefaultCommand)})
-                .AddCommandsFrom(new[] {typeof(HelloWorldDefaultCommand).Assembly})
+                .AddCommands(new[] { typeof(HelloWorldDefaultCommand) })
+                .AddCommandsFrom(new[] { typeof(HelloWorldDefaultCommand).Assembly })
                 .AddCommandsFromThisAssembly()
                 .AllowDebugMode()
                 .AllowPreviewMode()
@@ -30,8 +31,9 @@ namespace CliFx.Tests
                 .UseVersionText("test")
                 .UseDescription("test")
                 .UseConsole(new VirtualConsole(TextWriter.Null))
-                .UseCommandFactory(schema => (ICommand) Activator.CreateInstance(schema.Type))
+                .UseCommandFactory(schema => (ICommand)Activator.CreateInstance(schema.Type))
                 .UseCommandOptionInputConverter(new CommandOptionInputConverter())
+                .UseEnvironmentVariablesProvider(new EnvironmentVariablesProviderStub())
                 .Build();
         }
 

--- a/CliFx.Tests/CliApplicationBuilderTests.cs
+++ b/CliFx.Tests/CliApplicationBuilderTests.cs
@@ -1,9 +1,9 @@
-﻿using CliFx.Services;
-using CliFx.Tests.Stubs;
-using CliFx.Tests.TestCommands;
-using NUnit.Framework;
+﻿using NUnit.Framework;
 using System;
 using System.IO;
+using CliFx.Services;
+using CliFx.Tests.Stubs;
+using CliFx.Tests.TestCommands;
 
 namespace CliFx.Tests
 {

--- a/CliFx.Tests/CliApplicationTests.cs
+++ b/CliFx.Tests/CliApplicationTests.cs
@@ -206,10 +206,12 @@ namespace CliFx.Tests
             using (var stderrStream = new StringWriter())
             {
                 var console = new VirtualConsole(TextWriter.Null, stderrStream);
+                var environmentVariablesProvider = new EnvironmentVariablesProviderStub();
 
                 var application = new CliApplicationBuilder()
                     .AddCommands(commandTypes)
                     .UseVersionText(TestVersionText)
+                    .UseEnvironmentVariablesProvider(environmentVariablesProvider)
                     .UseConsole(console)
                     .Build();
 

--- a/CliFx.Tests/CliApplicationTests.cs
+++ b/CliFx.Tests/CliApplicationTests.cs
@@ -1,11 +1,12 @@
-﻿using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Threading.Tasks;
-using CliFx.Services;
+﻿using CliFx.Services;
+using CliFx.Tests.Stubs;
 using CliFx.Tests.TestCommands;
 using FluentAssertions;
 using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading.Tasks;
 
 namespace CliFx.Tests
 {
@@ -17,104 +18,104 @@ namespace CliFx.Tests
         private static IEnumerable<TestCaseData> GetTestCases_RunAsync()
         {
             yield return new TestCaseData(
-                new[] {typeof(HelloWorldDefaultCommand)},
+                new[] { typeof(HelloWorldDefaultCommand) },
                 new string[0],
                 "Hello world."
             );
-            
+
             yield return new TestCaseData(
-                new[] {typeof(ConcatCommand)},
-                new[] {"concat", "-i", "foo", "-i", "bar", "-s", " "},
+                new[] { typeof(ConcatCommand) },
+                new[] { "concat", "-i", "foo", "-i", "bar", "-s", " " },
                 "foo bar"
             );
-            
+
             yield return new TestCaseData(
-                new[] {typeof(ConcatCommand)},
-                new[] {"concat", "-i", "one", "two", "three", "-s", ", "},
+                new[] { typeof(ConcatCommand) },
+                new[] { "concat", "-i", "one", "two", "three", "-s", ", " },
                 "one, two, three"
             );
 
             yield return new TestCaseData(
-                new[] {typeof(DivideCommand)},
-                new[] {"div", "-D", "24", "-d", "8"},
+                new[] { typeof(DivideCommand) },
+                new[] { "div", "-D", "24", "-d", "8" },
                 "3"
             );
 
             yield return new TestCaseData(
-                new[] {typeof(HelloWorldDefaultCommand)},
-                new[] {"--version"},
+                new[] { typeof(HelloWorldDefaultCommand) },
+                new[] { "--version" },
                 TestVersionText
             );
 
             yield return new TestCaseData(
-                new[] {typeof(ConcatCommand)},
-                new[] {"--version"},
+                new[] { typeof(ConcatCommand) },
+                new[] { "--version" },
                 TestVersionText
             );
-            
+
             yield return new TestCaseData(
-                new[] {typeof(HelloWorldDefaultCommand)},
-                new[] {"-h"},
+                new[] { typeof(HelloWorldDefaultCommand) },
+                new[] { "-h" },
                 null
             );
 
             yield return new TestCaseData(
-                new[] {typeof(HelloWorldDefaultCommand)},
-                new[] {"--help"},
+                new[] { typeof(HelloWorldDefaultCommand) },
+                new[] { "--help" },
                 null
             );
-            
+
             yield return new TestCaseData(
-                new[] {typeof(ConcatCommand)},
+                new[] { typeof(ConcatCommand) },
                 new string[0],
                 null
             );
-            
+
             yield return new TestCaseData(
-                new[] {typeof(ConcatCommand)},
-                new[] {"-h"},
+                new[] { typeof(ConcatCommand) },
+                new[] { "-h" },
                 null
             );
 
             yield return new TestCaseData(
-                new[] {typeof(ConcatCommand)},
-                new[] {"--help"},
-                null
-            );
-            
-            yield return new TestCaseData(
-                new[] {typeof(ConcatCommand)},
-                new[] {"concat", "-h"},
+                new[] { typeof(ConcatCommand) },
+                new[] { "--help" },
                 null
             );
 
             yield return new TestCaseData(
-                new[] {typeof(ExceptionCommand)},
-                new[] {"exc", "-h"},
+                new[] { typeof(ConcatCommand) },
+                new[] { "concat", "-h" },
                 null
             );
 
             yield return new TestCaseData(
-                new[] {typeof(CommandExceptionCommand)},
-                new[] {"exc", "-h"},
+                new[] { typeof(ExceptionCommand) },
+                new[] { "exc", "-h" },
                 null
             );
 
             yield return new TestCaseData(
-                new[] {typeof(ConcatCommand)},
-                new[] {"[preview]"},
+                new[] { typeof(CommandExceptionCommand) },
+                new[] { "exc", "-h" },
                 null
             );
 
             yield return new TestCaseData(
-                new[] {typeof(ExceptionCommand)},
-                new[] {"exc", "[preview]"},
+                new[] { typeof(ConcatCommand) },
+                new[] { "[preview]" },
                 null
             );
 
             yield return new TestCaseData(
-                new[] {typeof(ConcatCommand)},
-                new[] {"concat", "[preview]", "-o", "value"},
+                new[] { typeof(ExceptionCommand) },
+                new[] { "exc", "[preview]" },
+                null
+            );
+
+            yield return new TestCaseData(
+                new[] { typeof(ConcatCommand) },
+                new[] { "concat", "[preview]", "-o", "value" },
                 null
             );
         }
@@ -128,38 +129,38 @@ namespace CliFx.Tests
             );
 
             yield return new TestCaseData(
-                new[] {typeof(ConcatCommand)},
-                new[] {"non-existing"},
+                new[] { typeof(ConcatCommand) },
+                new[] { "non-existing" },
                 null, null
             );
 
             yield return new TestCaseData(
-                new[] {typeof(ExceptionCommand)},
-                new[] {"exc"},
+                new[] { typeof(ExceptionCommand) },
+                new[] { "exc" },
                 null, null
             );
 
             yield return new TestCaseData(
-                new[] {typeof(CommandExceptionCommand)},
-                new[] {"exc"},
+                new[] { typeof(CommandExceptionCommand) },
+                new[] { "exc" },
                 null, null
             );
 
             yield return new TestCaseData(
-                new[] {typeof(CommandExceptionCommand)},
-                new[] {"exc"},
+                new[] { typeof(CommandExceptionCommand) },
+                new[] { "exc" },
                 null, null
             );
-         
+
             yield return new TestCaseData(
-                new[] {typeof(CommandExceptionCommand)},
-                new[] {"exc", "-m", "foo bar"},
+                new[] { typeof(CommandExceptionCommand) },
+                new[] { "exc", "-m", "foo bar" },
                 "foo bar", null
             );
-            
+
             yield return new TestCaseData(
-                new[] {typeof(CommandExceptionCommand)},
-                new[] {"exc", "-m", "foo bar", "-c", "666"},
+                new[] { typeof(CommandExceptionCommand) },
+                new[] { "exc", "-m", "foo bar", "-c", "666" },
                 "foo bar", 666
             );
         }
@@ -173,11 +174,13 @@ namespace CliFx.Tests
             using (var stdoutStream = new StringWriter())
             {
                 var console = new VirtualConsole(stdoutStream);
+                var environmentVariablesProvider = new EnvironmentVariablesProviderStub();
 
                 var application = new CliApplicationBuilder()
                     .AddCommands(commandTypes)
                     .UseVersionText(TestVersionText)
                     .UseConsole(console)
+                    .UseEnvironmentVariablesProvider(environmentVariablesProvider)
                     .Build();
 
                 // Act
@@ -219,7 +222,7 @@ namespace CliFx.Tests
                     exitCode.Should().Be(expectedExitCode);
                 else
                     exitCode.Should().NotBe(0);
-                
+
                 if (expectedStdErr != null)
                     stderr.Should().Be(expectedStdErr);
                 else

--- a/CliFx.Tests/CliApplicationTests.cs
+++ b/CliFx.Tests/CliApplicationTests.cs
@@ -1,12 +1,12 @@
-﻿using CliFx.Services;
-using CliFx.Tests.Stubs;
-using CliFx.Tests.TestCommands;
-using FluentAssertions;
+﻿using FluentAssertions;
 using NUnit.Framework;
 using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Threading.Tasks;
+using CliFx.Services;
+using CliFx.Tests.Stubs;
+using CliFx.Tests.TestCommands;
 
 namespace CliFx.Tests
 {

--- a/CliFx.Tests/Services/CommandInitializerTests.cs
+++ b/CliFx.Tests/Services/CommandInitializerTests.cs
@@ -1,13 +1,13 @@
-﻿using CliFx.Exceptions;
-using CliFx.Models;
-using CliFx.Services;
-using CliFx.Tests.Stubs;
-using CliFx.Tests.TestCommands;
-using FluentAssertions;
+﻿using FluentAssertions;
 using NUnit.Framework;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using CliFx.Exceptions;
+using CliFx.Models;
+using CliFx.Services;
+using CliFx.Tests.TestCommands;
+using CliFx.Tests.Stubs;
 
 namespace CliFx.Tests.Services
 {
@@ -77,7 +77,7 @@ namespace CliFx.Tests.Services
             yield return new TestCaseData(
                 new EnvironmentVariableCommand(),
                 GetCommandSchema(typeof(EnvironmentVariableCommand)),
-                new CommandInput(null, new CommandOptionInput[] { }),
+                new CommandInput(null, new CommandOptionInput[0], EnvironmentVariablesProviderStub.EnvironmentVariables),
                 new EnvironmentVariableCommand { Option = "A" }
             );
 
@@ -85,7 +85,7 @@ namespace CliFx.Tests.Services
             yield return new TestCaseData(
                 new EnvironmentVariableWithMultipleValuesCommand(),
                 GetCommandSchema(typeof(EnvironmentVariableWithMultipleValuesCommand)),
-                new CommandInput(null, new CommandOptionInput[] { }),
+                new CommandInput(null, new CommandOptionInput[0], EnvironmentVariablesProviderStub.EnvironmentVariables),
                 new EnvironmentVariableWithMultipleValuesCommand { Option = new[] { "A", "B", "C" } }
             );
 
@@ -95,9 +95,18 @@ namespace CliFx.Tests.Services
                 GetCommandSchema(typeof(EnvironmentVariableCommand)),
                 new CommandInput(null, new[]
                 {
-                    new CommandOptionInput("opt", new[] {"X"})
-                }),
+                    new CommandOptionInput("opt", new[] { "X" })
+                },
+                EnvironmentVariablesProviderStub.EnvironmentVariables),
                 new EnvironmentVariableCommand { Option = "X" }
+            );
+
+            //Will not split environment variable values because underlying property is not a collection
+            yield return new TestCaseData(
+                new EnvironmentVariableWithoutCollectionPropertyCommand(),
+                GetCommandSchema(typeof(EnvironmentVariableWithoutCollectionPropertyCommand)),
+                new CommandInput(null, new CommandOptionInput[0], EnvironmentVariablesProviderStub.EnvironmentVariables),
+                new EnvironmentVariableWithoutCollectionPropertyCommand { Option = "A;B;C;" }
             );
         }
 
@@ -140,7 +149,7 @@ namespace CliFx.Tests.Services
             ICommand expectedCommand)
         {
             // Arrange
-            var initializer = new CommandInitializer(new EnvironmentVariablesProviderStub());
+            var initializer = new CommandInitializer();
 
             // Act
             initializer.InitializeCommand(command, commandSchema, commandInput);
@@ -154,7 +163,7 @@ namespace CliFx.Tests.Services
         public void InitializeCommand_Negative_Test(ICommand command, CommandSchema commandSchema, CommandInput commandInput)
         {
             // Arrange
-            var initializer = new CommandInitializer(new EnvironmentVariablesProviderStub());
+            var initializer = new CommandInitializer();
 
             // Act & Assert
             initializer.Invoking(i => i.InitializeCommand(command, commandSchema, commandInput))

--- a/CliFx.Tests/Services/CommandInputParserTests.cs
+++ b/CliFx.Tests/Services/CommandInputParserTests.cs
@@ -1,8 +1,9 @@
-﻿using System.Collections.Generic;
+﻿using FluentAssertions;
+using NUnit.Framework;
+using System.Collections.Generic;
 using CliFx.Models;
 using CliFx.Services;
-using FluentAssertions;
-using NUnit.Framework;
+using CliFx.Tests.Stubs;
 
 namespace CliFx.Tests.Services
 {
@@ -11,203 +12,238 @@ namespace CliFx.Tests.Services
     {
         private static IEnumerable<TestCaseData> GetTestCases_ParseCommandInput()
         {
-            yield return new TestCaseData(new string[0], CommandInput.Empty);
+            yield return new TestCaseData(new string[0], CommandInput.Empty, new EmptyEnvironmentVariablesProviderStub());
 
             yield return new TestCaseData(
-                new[] {"--option", "value"},
+                new[] { "--option", "value" },
                 new CommandInput(new[]
                 {
                     new CommandOptionInput("option", "value")
-                })
+                }),
+                new EmptyEnvironmentVariablesProviderStub()
             );
 
             yield return new TestCaseData(
-                new[] {"--option1", "value1", "--option2", "value2"},
+                new[] { "--option1", "value1", "--option2", "value2" },
                 new CommandInput(new[]
                 {
                     new CommandOptionInput("option1", "value1"),
                     new CommandOptionInput("option2", "value2")
-                })
+                }),
+                new EmptyEnvironmentVariablesProviderStub()
             );
 
             yield return new TestCaseData(
-                new[] {"--option", "value1", "value2"},
+                new[] { "--option", "value1", "value2" },
                 new CommandInput(new[]
                 {
                     new CommandOptionInput("option", new[] {"value1", "value2"})
-                })
+                }),
+                new EmptyEnvironmentVariablesProviderStub()
             );
 
             yield return new TestCaseData(
-                new[] {"--option", "value1", "--option", "value2"},
+                new[] { "--option", "value1", "--option", "value2" },
                 new CommandInput(new[]
                 {
                     new CommandOptionInput("option", new[] {"value1", "value2"})
-                })
+                }),
+                new EmptyEnvironmentVariablesProviderStub()
             );
 
             yield return new TestCaseData(
-                new[] {"-a", "value"},
+                new[] { "-a", "value" },
                 new CommandInput(new[]
                 {
                     new CommandOptionInput("a", "value")
-                })
+                }),
+                new EmptyEnvironmentVariablesProviderStub()
             );
 
             yield return new TestCaseData(
-                new[] {"-a", "value1", "-b", "value2"},
+                new[] { "-a", "value1", "-b", "value2" },
                 new CommandInput(new[]
                 {
                     new CommandOptionInput("a", "value1"),
                     new CommandOptionInput("b", "value2")
-                })
+                }),
+                new EmptyEnvironmentVariablesProviderStub()
             );
 
             yield return new TestCaseData(
-                new[] {"-a", "value1", "value2"},
+                new[] { "-a", "value1", "value2" },
                 new CommandInput(new[]
                 {
                     new CommandOptionInput("a", new[] {"value1", "value2"})
-                })
+                }),
+                new EmptyEnvironmentVariablesProviderStub()
             );
 
             yield return new TestCaseData(
-                new[] {"-a", "value1", "-a", "value2"},
+                new[] { "-a", "value1", "-a", "value2" },
                 new CommandInput(new[]
                 {
                     new CommandOptionInput("a", new[] {"value1", "value2"})
-                })
+                }),
+                new EmptyEnvironmentVariablesProviderStub()
             );
 
             yield return new TestCaseData(
-                new[] {"--option1", "value1", "-b", "value2"},
+                new[] { "--option1", "value1", "-b", "value2" },
                 new CommandInput(new[]
                 {
                     new CommandOptionInput("option1", "value1"),
                     new CommandOptionInput("b", "value2")
-                })
+                }),
+                new EmptyEnvironmentVariablesProviderStub()
             );
 
             yield return new TestCaseData(
-                new[] {"--switch"},
+                new[] { "--switch" },
                 new CommandInput(new[]
                 {
                     new CommandOptionInput("switch")
-                })
+                }),
+                new EmptyEnvironmentVariablesProviderStub()
             );
 
             yield return new TestCaseData(
-                new[] {"--switch1", "--switch2"},
+                new[] { "--switch1", "--switch2" },
                 new CommandInput(new[]
                 {
                     new CommandOptionInput("switch1"),
                     new CommandOptionInput("switch2")
-                })
+                }),
+                new EmptyEnvironmentVariablesProviderStub()
             );
 
             yield return new TestCaseData(
-                new[] {"-s"},
+                new[] { "-s" },
                 new CommandInput(new[]
                 {
                     new CommandOptionInput("s")
-                })
+                }),
+                new EmptyEnvironmentVariablesProviderStub()
             );
 
             yield return new TestCaseData(
-                new[] {"-a", "-b"},
+                new[] { "-a", "-b" },
                 new CommandInput(new[]
                 {
                     new CommandOptionInput("a"),
                     new CommandOptionInput("b")
-                })
+                }),
+                new EmptyEnvironmentVariablesProviderStub()
             );
 
             yield return new TestCaseData(
-                new[] {"-ab"},
+                new[] { "-ab" },
                 new CommandInput(new[]
                 {
                     new CommandOptionInput("a"),
                     new CommandOptionInput("b")
-                })
+                }),
+                new EmptyEnvironmentVariablesProviderStub()
             );
 
             yield return new TestCaseData(
-                new[] {"-ab", "value"},
+                new[] { "-ab", "value" },
                 new CommandInput(new[]
                 {
                     new CommandOptionInput("a"),
                     new CommandOptionInput("b", "value")
-                })
+                }),
+                new EmptyEnvironmentVariablesProviderStub()
             );
 
             yield return new TestCaseData(
-                new[] {"command"},
-                new CommandInput("command")
+                new[] { "command" },
+                new CommandInput("command"),
+                new EmptyEnvironmentVariablesProviderStub()
             );
 
             yield return new TestCaseData(
-                new[] {"command", "--option", "value"},
+                new[] { "command", "--option", "value" },
                 new CommandInput("command", new[]
                 {
                     new CommandOptionInput("option", "value")
-                })
+                }),
+                new EmptyEnvironmentVariablesProviderStub()
             );
 
             yield return new TestCaseData(
-                new[] {"long", "command", "name"},
-                new CommandInput("long command name")
+                new[] { "long", "command", "name" },
+                new CommandInput("long command name"),
+                new EmptyEnvironmentVariablesProviderStub()
             );
 
             yield return new TestCaseData(
-                new[] {"long", "command", "name", "--option", "value"},
+                new[] { "long", "command", "name", "--option", "value" },
                 new CommandInput("long command name", new[]
                 {
                     new CommandOptionInput("option", "value")
-                })
+                }),
+                new EmptyEnvironmentVariablesProviderStub()
             );
 
             yield return new TestCaseData(
-                new[] {"[debug]"},
+                new[] { "[debug]" },
                 new CommandInput(null,
-                    new[] {"debug"},
-                    new CommandOptionInput[0])
+                    new[] { "debug" },
+                    new CommandOptionInput[0]),
+                new EmptyEnvironmentVariablesProviderStub()
             );
 
             yield return new TestCaseData(
-                new[] {"[debug]", "[preview]"},
+                new[] { "[debug]", "[preview]" },
                 new CommandInput(null,
-                    new[] {"debug", "preview"},
-                    new CommandOptionInput[0])
+                    new[] { "debug", "preview" },
+                    new CommandOptionInput[0]),
+                new EmptyEnvironmentVariablesProviderStub()
             );
 
             yield return new TestCaseData(
-                new[] {"[debug]", "[preview]", "-o", "value"},
+                new[] { "[debug]", "[preview]", "-o", "value" },
                 new CommandInput(null,
-                    new[] {"debug", "preview"},
+                    new[] { "debug", "preview" },
                     new[]
                     {
                         new CommandOptionInput("o", "value")
-                    })
+                    }),
+                new EmptyEnvironmentVariablesProviderStub()
             );
 
             yield return new TestCaseData(
-                new[] {"command", "[debug]", "[preview]", "-o", "value"},
+                new[] { "command", "[debug]", "[preview]", "-o", "value" },
                 new CommandInput("command",
-                    new[] {"debug", "preview"},
+                    new[] { "debug", "preview" },
                     new[]
                     {
                         new CommandOptionInput("o", "value")
-                    })
+                    }),
+                new EmptyEnvironmentVariablesProviderStub()
+            );
+
+            yield return new TestCaseData(
+                new[] { "command", "[debug]", "[preview]", "-o", "value" },
+                new CommandInput("command",
+                    new[] { "debug", "preview" },
+                    new[]
+                    {
+                        new CommandOptionInput("o", "value")
+                    },
+                    EnvironmentVariablesProviderStub.EnvironmentVariables),
+                new EnvironmentVariablesProviderStub()
             );
         }
 
         [Test]
         [TestCaseSource(nameof(GetTestCases_ParseCommandInput))]
         public void ParseCommandInput_Test(IReadOnlyList<string> commandLineArguments,
-            CommandInput expectedCommandInput)
+            CommandInput expectedCommandInput, IEnvironmentVariablesProvider environmentVariablesProvider)
         {
             // Arrange
-            var parser = new CommandInputParser();
+            var parser = new CommandInputParser(environmentVariablesProvider);
 
             // Act
             var commandInput = parser.ParseCommandInput(commandLineArguments);

--- a/CliFx.Tests/Services/CommandSchemaResolverTests.cs
+++ b/CliFx.Tests/Services/CommandSchemaResolverTests.cs
@@ -1,11 +1,11 @@
-﻿using CliFx.Exceptions;
-using CliFx.Models;
-using CliFx.Services;
-using CliFx.Tests.TestCommands;
-using FluentAssertions;
+﻿using FluentAssertions;
 using NUnit.Framework;
 using System;
 using System.Collections.Generic;
+using CliFx.Exceptions;
+using CliFx.Models;
+using CliFx.Services;
+using CliFx.Tests.TestCommands;
 
 namespace CliFx.Tests.Services
 {
@@ -34,11 +34,11 @@ namespace CliFx.Tests.Services
                             new CommandOptionSchema(typeof(ConcatCommand).GetProperty(nameof(ConcatCommand.Separator)),
                                 null, 's', false, "String separator.", null)
                         }),
-                    new CommandSchema(typeof(EnvironmentVariableCommand), null, "Read option values from environment variables.",
+                    new CommandSchema(typeof(EnvironmentVariableCommand), null, "Reads option values from environment variables.",
                         new[]
                         {
                             new CommandOptionSchema(typeof(EnvironmentVariableCommand).GetProperty(nameof(EnvironmentVariableCommand.Option)),
-                                "opt", null, false, null, "ENV_VAR_1")
+                                "opt", null, false, null, "ENV_SINGLE_VALUE")
                         }
                     )
                 }

--- a/CliFx.Tests/Services/CommandSchemaResolverTests.cs
+++ b/CliFx.Tests/Services/CommandSchemaResolverTests.cs
@@ -1,11 +1,11 @@
-﻿using System;
-using System.Collections.Generic;
-using CliFx.Exceptions;
+﻿using CliFx.Exceptions;
 using CliFx.Models;
 using CliFx.Services;
 using CliFx.Tests.TestCommands;
 using FluentAssertions;
 using NUnit.Framework;
+using System;
+using System.Collections.Generic;
 
 namespace CliFx.Tests.Services
 {
@@ -14,15 +14,15 @@ namespace CliFx.Tests.Services
     {
         private static IEnumerable<TestCaseData> GetTestCases_GetCommandSchemas()
         {
-			yield return new TestCaseData(
-				new[] { typeof(DivideCommand), typeof(ConcatCommand), typeof(EnvironmentVariableCommand) },
-				new[]
-				{
-					new CommandSchema(typeof(DivideCommand), "div", "Divide one number by another.",
-						new[]
-						{
-							new CommandOptionSchema(typeof(DivideCommand).GetProperty(nameof(DivideCommand.Dividend)),
-								"dividend", 'D', true, "The number to divide.", null),
+            yield return new TestCaseData(
+                new[] { typeof(DivideCommand), typeof(ConcatCommand), typeof(EnvironmentVariableCommand) },
+                new[]
+                {
+                    new CommandSchema(typeof(DivideCommand), "div", "Divide one number by another.",
+                        new[]
+                        {
+                            new CommandOptionSchema(typeof(DivideCommand).GetProperty(nameof(DivideCommand.Dividend)),
+                                "dividend", 'D', true, "The number to divide.", null),
                             new CommandOptionSchema(typeof(DivideCommand).GetProperty(nameof(DivideCommand.Divisor)),
                                 "divisor", 'd', true, "The number to divide by.", null)
                         }),
@@ -34,18 +34,18 @@ namespace CliFx.Tests.Services
                             new CommandOptionSchema(typeof(ConcatCommand).GetProperty(nameof(ConcatCommand.Separator)),
                                 null, 's', false, "String separator.", null)
                         }),
-					new CommandSchema(typeof(EnvironmentVariableCommand), null, "Read options from environment variables.",
-						new[]
-						{
-							new CommandOptionSchema(typeof(EnvironmentVariableCommand).GetProperty(nameof(EnvironmentVariableCommand.Option)),
-								"opt", null, false, null, "OPTION_VALUE_FROM_ENV")
-						}
-					)
+                    new CommandSchema(typeof(EnvironmentVariableCommand), null, "Read option values from environment variables.",
+                        new[]
+                        {
+                            new CommandOptionSchema(typeof(EnvironmentVariableCommand).GetProperty(nameof(EnvironmentVariableCommand.Option)),
+                                "opt", null, false, null, "ENV_VAR_1")
+                        }
+                    )
                 }
             );
 
             yield return new TestCaseData(
-                new[] {typeof(HelloWorldDefaultCommand)},
+                new[] { typeof(HelloWorldDefaultCommand) },
                 new[]
                 {
                     new CommandSchema(typeof(HelloWorldDefaultCommand), null, null, new CommandOptionSchema[0])
@@ -69,7 +69,7 @@ namespace CliFx.Tests.Services
             {
                 new[] {typeof(NonAnnotatedCommand)}
             });
-            
+
             yield return new TestCaseData(new object[]
             {
                 new[] {typeof(DuplicateOptionNamesCommand)}
@@ -79,7 +79,7 @@ namespace CliFx.Tests.Services
             {
                 new[] {typeof(DuplicateOptionShortNamesCommand)}
             });
-            
+
             yield return new TestCaseData(new object[]
             {
                 new[] {typeof(ExceptionCommand), typeof(CommandExceptionCommand)}

--- a/CliFx.Tests/Services/CommandSchemaResolverTests.cs
+++ b/CliFx.Tests/Services/CommandSchemaResolverTests.cs
@@ -14,26 +14,33 @@ namespace CliFx.Tests.Services
     {
         private static IEnumerable<TestCaseData> GetTestCases_GetCommandSchemas()
         {
-            yield return new TestCaseData(
-                new[] {typeof(DivideCommand), typeof(ConcatCommand)},
-                new[]
-                {
-                    new CommandSchema(typeof(DivideCommand), "div", "Divide one number by another.",
-                        new[]
-                        {
-                            new CommandOptionSchema(typeof(DivideCommand).GetProperty(nameof(DivideCommand.Dividend)),
-                                "dividend", 'D', true, "The number to divide."),
+			yield return new TestCaseData(
+				new[] { typeof(DivideCommand), typeof(ConcatCommand), typeof(EnvironmentVariableCommand) },
+				new[]
+				{
+					new CommandSchema(typeof(DivideCommand), "div", "Divide one number by another.",
+						new[]
+						{
+							new CommandOptionSchema(typeof(DivideCommand).GetProperty(nameof(DivideCommand.Dividend)),
+								"dividend", 'D', true, "The number to divide.", null),
                             new CommandOptionSchema(typeof(DivideCommand).GetProperty(nameof(DivideCommand.Divisor)),
-                                "divisor", 'd', true, "The number to divide by.")
+                                "divisor", 'd', true, "The number to divide by.", null)
                         }),
                     new CommandSchema(typeof(ConcatCommand), "concat", "Concatenate strings.",
                         new[]
                         {
                             new CommandOptionSchema(typeof(ConcatCommand).GetProperty(nameof(ConcatCommand.Inputs)),
-                                null, 'i', true, "Input strings."),
+                                null, 'i', true, "Input strings.", null),
                             new CommandOptionSchema(typeof(ConcatCommand).GetProperty(nameof(ConcatCommand.Separator)),
-                                null, 's', false, "String separator.")
-                        })
+                                null, 's', false, "String separator.", null)
+                        }),
+					new CommandSchema(typeof(EnvironmentVariableCommand), null, "Read options from environment variables.",
+						new[]
+						{
+							new CommandOptionSchema(typeof(EnvironmentVariableCommand).GetProperty(nameof(EnvironmentVariableCommand.Option)),
+								"opt", null, false, null, "OPTION_VALUE_FROM_ENV")
+						}
+					)
                 }
             );
 

--- a/CliFx.Tests/Stubs/EmptyEnvironmentVariablesProviderStub.cs
+++ b/CliFx.Tests/Stubs/EmptyEnvironmentVariablesProviderStub.cs
@@ -1,0 +1,10 @@
+﻿using System.Collections.Generic;
+using CliFx.Services;
+
+namespace CliFx.Tests.Stubs
+{
+    public class EmptyEnvironmentVariablesProviderStub : IEnvironmentVariablesProvider
+    {
+        public IReadOnlyDictionary<string, string> GetEnvironmentVariables() => new Dictionary<string, string>();
+    }
+}

--- a/CliFx.Tests/Stubs/EnvironmentVariablesProviderStub.cs
+++ b/CliFx.Tests/Stubs/EnvironmentVariablesProviderStub.cs
@@ -1,0 +1,25 @@
+﻿using CliFx.Services;
+using System;
+using System.Collections.Generic;
+
+namespace CliFx.Tests.Stubs
+{
+    public class EnvironmentVariablesProviderStub : IEnvironmentVariablesProvider
+    {
+        private readonly Dictionary<string, IReadOnlyList<string>> _variablesWithValues = new Dictionary<string, IReadOnlyList<string>>
+        {
+            ["ENV_VAR_1"] = new[] { "A" },
+            ["ENV_VAR_2"] = new[] { "A", "B", "C" }
+        };
+
+        public IReadOnlyList<string> GetValues(string variableName)
+        {
+            if (variableName == null) return null;
+
+            if (!_variablesWithValues.ContainsKey(variableName))
+                throw new NotSupportedException($"${variableName} does not exist, did you forget to add it to the variables dictionary?");
+
+            return _variablesWithValues[variableName];
+        }
+    }
+}

--- a/CliFx.Tests/Stubs/EnvironmentVariablesProviderStub.cs
+++ b/CliFx.Tests/Stubs/EnvironmentVariablesProviderStub.cs
@@ -1,25 +1,18 @@
-﻿using CliFx.Services;
-using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
+using System.IO;
+using CliFx.Services;
 
 namespace CliFx.Tests.Stubs
 {
     public class EnvironmentVariablesProviderStub : IEnvironmentVariablesProvider
     {
-        private readonly Dictionary<string, IReadOnlyList<string>> _variablesWithValues = new Dictionary<string, IReadOnlyList<string>>
+        public static readonly Dictionary<string, string> EnvironmentVariables = new Dictionary<string, string>
         {
-            ["ENV_VAR_1"] = new[] { "A" },
-            ["ENV_VAR_2"] = new[] { "A", "B", "C" }
+            ["ENV_SINGLE_VALUE"] = "A",
+            ["ENV_MULTIPLE_VALUES"] = $"A{Path.PathSeparator}B{Path.PathSeparator}C{Path.PathSeparator}",
+            ["ENV_ESCAPED_MULTIPLE_VALUES"] = $"\"A{Path.PathSeparator}B{Path.PathSeparator}C{Path.PathSeparator}\""
         };
 
-        public IReadOnlyList<string> GetValues(string variableName)
-        {
-            if (variableName == null) return null;
-
-            if (!_variablesWithValues.ContainsKey(variableName))
-                throw new NotSupportedException($"${variableName} does not exist, did you forget to add it to the variables dictionary?");
-
-            return _variablesWithValues[variableName];
-        }
+        public IReadOnlyDictionary<string, string> GetEnvironmentVariables() => EnvironmentVariables;
     }
 }

--- a/CliFx.Tests/TestCommands/EnvironmentVariableCommand.cs
+++ b/CliFx.Tests/TestCommands/EnvironmentVariableCommand.cs
@@ -1,0 +1,15 @@
+﻿using CliFx.Attributes;
+using CliFx.Services;
+using System.Threading.Tasks;
+
+namespace CliFx.Tests.TestCommands
+{
+	[Command(Description = "Read options from environment variables.")]
+	public class EnvironmentVariableCommand : ICommand
+	{
+		[CommandOption("opt", EnvironmentVariableName = "OPTION_VALUE_FROM_ENV")]
+		public string Option { get; set; }
+
+		public Task ExecuteAsync(IConsole console) => Task.CompletedTask;
+	}
+}

--- a/CliFx.Tests/TestCommands/EnvironmentVariableCommand.cs
+++ b/CliFx.Tests/TestCommands/EnvironmentVariableCommand.cs
@@ -4,10 +4,10 @@ using System.Threading.Tasks;
 
 namespace CliFx.Tests.TestCommands
 {
-	[Command(Description = "Read options from environment variables.")]
+	[Command(Description = "Read option values from environment variables.")]
 	public class EnvironmentVariableCommand : ICommand
 	{
-		[CommandOption("opt", EnvironmentVariableName = "OPTION_VALUE_FROM_ENV")]
+		[CommandOption("opt", EnvironmentVariableName = "ENV_VAR_1")]
 		public string Option { get; set; }
 
 		public Task ExecuteAsync(IConsole console) => Task.CompletedTask;

--- a/CliFx.Tests/TestCommands/EnvironmentVariableCommand.cs
+++ b/CliFx.Tests/TestCommands/EnvironmentVariableCommand.cs
@@ -1,13 +1,13 @@
-﻿using CliFx.Attributes;
+﻿using System.Threading.Tasks;
+using CliFx.Attributes;
 using CliFx.Services;
-using System.Threading.Tasks;
 
 namespace CliFx.Tests.TestCommands
 {
-	[Command(Description = "Read option values from environment variables.")]
+	[Command(Description = "Reads option values from environment variables.")]
 	public class EnvironmentVariableCommand : ICommand
 	{
-		[CommandOption("opt", EnvironmentVariableName = "ENV_VAR_1")]
+		[CommandOption("opt", EnvironmentVariableName = "ENV_SINGLE_VALUE")]
 		public string Option { get; set; }
 
 		public Task ExecuteAsync(IConsole console) => Task.CompletedTask;

--- a/CliFx.Tests/TestCommands/EnvironmentVariableWithMultipleValuesCommand.cs
+++ b/CliFx.Tests/TestCommands/EnvironmentVariableWithMultipleValuesCommand.cs
@@ -1,0 +1,16 @@
+﻿using CliFx.Attributes;
+using CliFx.Services;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace CliFx.Tests.TestCommands
+{
+	[Command(Description = "Read multiple option values from environment variables.")]
+	public class EnvironmentVariableWithMultipleValuesCommand : ICommand
+	{
+		[CommandOption("opt", EnvironmentVariableName = "ENV_VAR_2")]
+		public IEnumerable<string> Option { get; set; }
+
+		public Task ExecuteAsync(IConsole console) => Task.CompletedTask;
+	}
+}

--- a/CliFx.Tests/TestCommands/EnvironmentVariableWithMultipleValuesCommand.cs
+++ b/CliFx.Tests/TestCommands/EnvironmentVariableWithMultipleValuesCommand.cs
@@ -1,14 +1,14 @@
-﻿using CliFx.Attributes;
-using CliFx.Services;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Threading.Tasks;
+using CliFx.Attributes;
+using CliFx.Services;
 
 namespace CliFx.Tests.TestCommands
 {
-	[Command(Description = "Read multiple option values from environment variables.")]
+	[Command(Description = "Reads multiple option values from environment variables.")]
 	public class EnvironmentVariableWithMultipleValuesCommand : ICommand
 	{
-		[CommandOption("opt", EnvironmentVariableName = "ENV_VAR_2")]
+		[CommandOption("opt", EnvironmentVariableName = "ENV_MULTIPLE_VALUES")]
 		public IEnumerable<string> Option { get; set; }
 
 		public Task ExecuteAsync(IConsole console) => Task.CompletedTask;

--- a/CliFx.Tests/TestCommands/EnvironmentVariableWithoutCollectionPropertyCommand.cs
+++ b/CliFx.Tests/TestCommands/EnvironmentVariableWithoutCollectionPropertyCommand.cs
@@ -1,0 +1,16 @@
+﻿using System.Collections.Generic;
+using System.Threading.Tasks;
+using CliFx.Attributes;
+using CliFx.Services;
+
+namespace CliFx.Tests.TestCommands
+{
+    [Command(Description = "Reads one option value from environment variables because target property is not a collection.")]
+    public class EnvironmentVariableWithoutCollectionPropertyCommand : ICommand
+    {
+        [CommandOption("opt", EnvironmentVariableName = "ENV_MULTIPLE_VALUES")]
+        public string Option { get; set; }
+
+        public Task ExecuteAsync(IConsole console) => Task.CompletedTask;
+    }
+}

--- a/CliFx.v3.ncrunchsolution
+++ b/CliFx.v3.ncrunchsolution
@@ -1,6 +1,0 @@
-﻿<SolutionConfiguration>
-  <Settings>
-    <AllowParallelTestExecution>True</AllowParallelTestExecution>
-    <SolutionConfigured>True</SolutionConfigured>
-  </Settings>
-</SolutionConfiguration>

--- a/CliFx.v3.ncrunchsolution
+++ b/CliFx.v3.ncrunchsolution
@@ -1,0 +1,6 @@
+﻿<SolutionConfiguration>
+  <Settings>
+    <AllowParallelTestExecution>True</AllowParallelTestExecution>
+    <SolutionConfigured>True</SolutionConfigured>
+  </Settings>
+</SolutionConfiguration>

--- a/CliFx/Attributes/CommandOptionAttribute.cs
+++ b/CliFx/Attributes/CommandOptionAttribute.cs
@@ -28,6 +28,11 @@ namespace CliFx.Attributes
         /// </summary>
         public string Description { get; set; }
 
+		/// <summary>
+		/// Optional environment variable name that will be used as fallback value if no option value is specified.
+		/// </summary>
+		public string EnvironmentVariableName { get; set; }
+
         /// <summary>
         /// Initializes an instance of <see cref="CommandOptionAttribute"/>.
         /// </summary>

--- a/CliFx/Attributes/CommandOptionAttribute.cs
+++ b/CliFx/Attributes/CommandOptionAttribute.cs
@@ -28,10 +28,10 @@ namespace CliFx.Attributes
         /// </summary>
         public string Description { get; set; }
 
-		/// <summary>
-		/// Optional environment variable name that will be used as fallback value if no option value is specified.
-		/// </summary>
-		public string EnvironmentVariableName { get; set; }
+        /// <summary>
+        /// Optional environment variable name that will be used as fallback value if no option value is specified.
+        /// </summary>
+        public string EnvironmentVariableName { get; set; }
 
         /// <summary>
         /// Initializes an instance of <see cref="CommandOptionAttribute"/>.
@@ -46,7 +46,7 @@ namespace CliFx.Attributes
         /// Initializes an instance of <see cref="CommandOptionAttribute"/>.
         /// </summary>
         public CommandOptionAttribute(string name, char shortName)
-            : this(name, (char?) shortName)
+            : this(name, (char?)shortName)
         {
         }
 

--- a/CliFx/CliApplicationBuilder.cs
+++ b/CliFx/CliApplicationBuilder.cs
@@ -1,12 +1,12 @@
-﻿using System;
+﻿using CliFx.Attributes;
+using CliFx.Internal;
+using CliFx.Models;
+using CliFx.Services;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Reflection;
-using CliFx.Attributes;
-using CliFx.Internal;
-using CliFx.Models;
-using CliFx.Services;
 
 namespace CliFx
 {
@@ -26,6 +26,7 @@ namespace CliFx
         private IConsole _console;
         private ICommandFactory _commandFactory;
         private ICommandOptionInputConverter _commandOptionInputConverter;
+        private IEnvironmentVariablesProvider _environmentVariablesProvider;
 
         /// <inheritdoc />
         public ICliApplicationBuilder AddCommand(Type commandType)
@@ -117,6 +118,13 @@ namespace CliFx
         }
 
         /// <inheritdoc />
+        public ICliApplicationBuilder UseEnvironmentVariablesProvider(IEnvironmentVariablesProvider environmentVariablesProvider)
+        {
+            _environmentVariablesProvider = environmentVariablesProvider.GuardNotNull(nameof(environmentVariablesProvider));
+            return this;
+        }
+
+        /// <inheritdoc />
         public ICliApplication Build()
         {
             // Use defaults for required parameters that were not configured
@@ -126,6 +134,7 @@ namespace CliFx
             _console = _console ?? new SystemConsole();
             _commandFactory = _commandFactory ?? new CommandFactory();
             _commandOptionInputConverter = _commandOptionInputConverter ?? new CommandOptionInputConverter();
+            _environmentVariablesProvider = _environmentVariablesProvider ?? new EnvironmentVariablesProvider();
 
             // Project parameters to expected types
             var metadata = new ApplicationMetadata(_title, _executableName, _versionText, _description);
@@ -133,7 +142,7 @@ namespace CliFx
 
             return new CliApplication(metadata, configuration,
                 _console, new CommandInputParser(), new CommandSchemaResolver(),
-                _commandFactory, new CommandInitializer(_commandOptionInputConverter, new EnvironmentVariablesProvider()), new HelpTextRenderer());
+                _commandFactory, new CommandInitializer(_commandOptionInputConverter, _environmentVariablesProvider), new HelpTextRenderer());
         }
     }
 

--- a/CliFx/CliApplicationBuilder.cs
+++ b/CliFx/CliApplicationBuilder.cs
@@ -133,7 +133,7 @@ namespace CliFx
 
             return new CliApplication(metadata, configuration,
                 _console, new CommandInputParser(), new CommandSchemaResolver(),
-                _commandFactory, new CommandInitializer(_commandOptionInputConverter), new HelpTextRenderer());
+                _commandFactory, new CommandInitializer(_commandOptionInputConverter, new EnvironmentVariablesProvider()), new HelpTextRenderer());
         }
     }
 

--- a/CliFx/CliApplicationBuilder.cs
+++ b/CliFx/CliApplicationBuilder.cs
@@ -1,12 +1,12 @@
-﻿using CliFx.Attributes;
-using CliFx.Internal;
-using CliFx.Models;
-using CliFx.Services;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using CliFx.Attributes;
+using CliFx.Internal;
+using CliFx.Models;
+using CliFx.Services;
 
 namespace CliFx
 {
@@ -141,8 +141,8 @@ namespace CliFx
             var configuration = new ApplicationConfiguration(_commandTypes.ToArray(), _isDebugModeAllowed, _isPreviewModeAllowed);
 
             return new CliApplication(metadata, configuration,
-                _console, new CommandInputParser(), new CommandSchemaResolver(),
-                _commandFactory, new CommandInitializer(_commandOptionInputConverter, _environmentVariablesProvider), new HelpTextRenderer());
+                _console, new CommandInputParser(_environmentVariablesProvider), new CommandSchemaResolver(),
+                _commandFactory, new CommandInitializer(_commandOptionInputConverter, new EnvironmentVariablesParser()), new HelpTextRenderer());
         }
     }
 

--- a/CliFx/ICliApplicationBuilder.cs
+++ b/CliFx/ICliApplicationBuilder.cs
@@ -1,6 +1,6 @@
-﻿using CliFx.Services;
-using System;
+﻿using System;
 using System.Reflection;
+using CliFx.Services;
 
 namespace CliFx
 {

--- a/CliFx/ICliApplicationBuilder.cs
+++ b/CliFx/ICliApplicationBuilder.cs
@@ -1,6 +1,6 @@
-﻿using System;
+﻿using CliFx.Services;
+using System;
 using System.Reflection;
-using CliFx.Services;
 
 namespace CliFx
 {
@@ -63,6 +63,11 @@ namespace CliFx
         /// Configures application to use specified implementation of <see cref="ICommandOptionInputConverter"/>.
         /// </summary>
         ICliApplicationBuilder UseCommandOptionInputConverter(ICommandOptionInputConverter converter);
+
+        /// <summary>
+        /// Configures application to use specified implementation of <see cref="IEnvironmentVariablesProvider"/>.
+        /// </summary>
+        ICliApplicationBuilder UseEnvironmentVariablesProvider(IEnvironmentVariablesProvider environmentVariablesProvider);
 
         /// <summary>
         /// Creates an instance of <see cref="ICliApplication"/> using configured parameters.

--- a/CliFx/Models/CommandInput.cs
+++ b/CliFx/Models/CommandInput.cs
@@ -26,13 +26,35 @@ namespace CliFx.Models
         public IReadOnlyList<CommandOptionInput> Options { get; }
 
         /// <summary>
+        /// Environment variables available when the command was parsed
+        /// </summary>
+        public IReadOnlyDictionary<string, string> EnvironmentVariables { get; }
+
+        /// <summary>
         /// Initializes an instance of <see cref="CommandInput"/>.
         /// </summary>
-        public CommandInput(string commandName, IReadOnlyList<string> directives, IReadOnlyList<CommandOptionInput> options)
+        public CommandInput(string commandName, IReadOnlyList<string> directives, IReadOnlyList<CommandOptionInput> options, IReadOnlyDictionary<string, string> environmentVariables)
         {
             CommandName = commandName; // can be null
             Directives = directives.GuardNotNull(nameof(directives));
             Options = options.GuardNotNull(nameof(options));
+            EnvironmentVariables = environmentVariables.GuardNotNull(nameof(environmentVariables));
+        }
+
+        /// <summary>
+        /// Initializes an instance of <see cref="CommandInput"/>.
+        /// </summary>
+        public CommandInput(string commandName, IReadOnlyList<string> directives, IReadOnlyList<CommandOptionInput> options)
+            : this(commandName, directives, options, EmptyEnvironmentVariables)
+        {
+        }
+
+        /// <summary>
+        /// Initializes an instance of <see cref="CommandInput"/>.
+        /// </summary>
+        public CommandInput(string commandName, IReadOnlyList<CommandOptionInput> options, IReadOnlyDictionary<string, string> environmentVariables)
+            : this(commandName, EmptyDirectives, options, environmentVariables)
+        {
         }
 
         /// <summary>
@@ -87,6 +109,7 @@ namespace CliFx.Models
     {
         private static readonly IReadOnlyList<string> EmptyDirectives = new string[0];
         private static readonly IReadOnlyList<CommandOptionInput> EmptyOptions = new CommandOptionInput[0];
+        private static readonly IReadOnlyDictionary<string, string> EmptyEnvironmentVariables = new Dictionary<string, string>();
 
         /// <summary>
         /// Empty input.

--- a/CliFx/Models/CommandOptionSchema.cs
+++ b/CliFx/Models/CommandOptionSchema.cs
@@ -1,6 +1,6 @@
-﻿using System.Reflection;
+﻿using CliFx.Internal;
+using System.Reflection;
 using System.Text;
-using CliFx.Internal;
 
 namespace CliFx.Models
 {
@@ -34,10 +34,10 @@ namespace CliFx.Models
         /// </summary>
         public string Description { get; }
 
-		/// <summary>
-		/// Optional environment variable name that will be used as fallback value if no option value is specified.
-		/// </summary>
-		public string EnvironmentVariableName { get; }
+        /// <summary>
+        /// Optional environment variable name that will be used as fallback value if no option value is specified.
+        /// </summary>
+        public string EnvironmentVariableName { get; }
 
         /// <summary>
         /// Initializes an instance of <see cref="CommandOptionSchema"/>.
@@ -49,7 +49,7 @@ namespace CliFx.Models
             ShortName = shortName; // can be null
             IsRequired = isRequired;
             Description = description; // can be null
-			EnvironmentVariableName = environmentVariableName; //can be null
+            EnvironmentVariableName = environmentVariableName; //can be null
         }
 
         /// <inheritdoc />

--- a/CliFx/Models/CommandOptionSchema.cs
+++ b/CliFx/Models/CommandOptionSchema.cs
@@ -34,16 +34,22 @@ namespace CliFx.Models
         /// </summary>
         public string Description { get; }
 
+		/// <summary>
+		/// Optional environment variable name that will be used as fallback value if no option value is specified.
+		/// </summary>
+		public string EnvironmentVariableName { get; }
+
         /// <summary>
         /// Initializes an instance of <see cref="CommandOptionSchema"/>.
         /// </summary>
-        public CommandOptionSchema(PropertyInfo property, string name, char? shortName, bool isRequired, string description)
+        public CommandOptionSchema(PropertyInfo property, string name, char? shortName, bool isRequired, string description, string environmentVariableName)
         {
             Property = property; // can be null
             Name = name; // can be null
             ShortName = shortName; // can be null
             IsRequired = isRequired;
             Description = description; // can be null
+			EnvironmentVariableName = environmentVariableName; //can be null
         }
 
         /// <inheritdoc />
@@ -75,9 +81,9 @@ namespace CliFx.Models
         // ...in CliApplication (when reading) and HelpTextRenderer (when writing).
 
         internal static CommandOptionSchema HelpOption { get; } =
-            new CommandOptionSchema(null, "help", 'h', false, "Shows help text.");
+            new CommandOptionSchema(null, "help", 'h', false, "Shows help text.", null);
 
         internal static CommandOptionSchema VersionOption { get; } =
-            new CommandOptionSchema(null, "version", null, false, "Shows version information.");
+            new CommandOptionSchema(null, "version", null, false, "Shows version information.", null);
     }
 }

--- a/CliFx/Models/CommandOptionSchema.cs
+++ b/CliFx/Models/CommandOptionSchema.cs
@@ -1,6 +1,6 @@
-﻿using CliFx.Internal;
-using System.Reflection;
+﻿using System.Reflection;
 using System.Text;
+using CliFx.Internal;
 
 namespace CliFx.Models
 {

--- a/CliFx/Models/Extensions.cs
+++ b/CliFx/Models/Extensions.cs
@@ -73,17 +73,6 @@ namespace CliFx.Models
         }
 
         /// <summary>
-        /// Finds an option that matches specified alias, or null if not found.
-        /// </summary>
-        public static CommandOptionSchema FindByAlias(this IReadOnlyList<CommandOptionSchema> optionSchemas, string alias)
-        {
-            optionSchemas.GuardNotNull(nameof(optionSchemas));
-            alias.GuardNotNull(nameof(alias));
-
-            return optionSchemas.FirstOrDefault(o => o.MatchesAlias(alias));
-        }
-
-        /// <summary>
         /// Finds an option input that matches the option schema specified, or null if not found.
         /// </summary>
         public static CommandOptionInput FindByOptionSchema(this IReadOnlyList<CommandOptionInput> optionInputs, CommandOptionSchema optionSchema)

--- a/CliFx/Models/Extensions.cs
+++ b/CliFx/Models/Extensions.cs
@@ -1,7 +1,7 @@
-﻿using System;
+﻿using CliFx.Internal;
+using System;
 using System.Collections.Generic;
 using System.Linq;
-using CliFx.Internal;
 
 namespace CliFx.Models
 {
@@ -71,7 +71,7 @@ namespace CliFx.Models
 
             return matchesByName || matchesByShortName;
         }
-        
+
         /// <summary>
         /// Finds an option that matches specified alias, or null if not found.
         /// </summary>
@@ -81,6 +81,17 @@ namespace CliFx.Models
             alias.GuardNotNull(nameof(alias));
 
             return optionSchemas.FirstOrDefault(o => o.MatchesAlias(alias));
+        }
+
+        /// <summary>
+        /// Finds an option input that matches the option schema specified, or null if not found.
+        /// </summary>
+        public static CommandOptionInput FindByOptionSchema(this IReadOnlyList<CommandOptionInput> optionInputs, CommandOptionSchema optionSchema)
+        {
+            optionInputs.GuardNotNull(nameof(optionInputs));
+            optionSchema.GuardNotNull(nameof(optionSchema));
+
+            return optionInputs.FirstOrDefault(o => optionSchema.MatchesAlias(o.Alias));
         }
 
         /// <summary>

--- a/CliFx/Services/CommandInputParser.cs
+++ b/CliFx/Services/CommandInputParser.cs
@@ -12,6 +12,26 @@ namespace CliFx.Services
     /// </summary>
     public class CommandInputParser : ICommandInputParser
     {
+        private readonly IEnvironmentVariablesProvider _environmentVariablesProvider;
+
+        /// <summary>
+        /// Initializes an instance of <see cref="CommandInputParser"/>
+        /// </summary>
+        public CommandInputParser(IEnvironmentVariablesProvider environmentVariablesProvider)
+        {
+            environmentVariablesProvider.GuardNotNull(nameof(environmentVariablesProvider));
+
+            _environmentVariablesProvider = environmentVariablesProvider;
+        }
+
+        /// <summary>
+        /// Initializes an instance of <see cref="CommandInputParser"/>
+        /// </summary>
+        public CommandInputParser()
+            : this(new EnvironmentVariablesProvider())
+        {
+        }
+
         /// <inheritdoc />
         public CommandInput ParseCommandInput(IReadOnlyList<string> commandLineArguments)
         {
@@ -78,7 +98,9 @@ namespace CliFx.Services
             var commandName = commandNameBuilder.Length > 0 ? commandNameBuilder.ToString() : null;
             var options = optionsDic.Select(p => new CommandOptionInput(p.Key, p.Value)).ToArray();
 
-            return new CommandInput(commandName, directives, options);
+            var environmentVariables = _environmentVariablesProvider.GetEnvironmentVariables();
+
+            return new CommandInput(commandName, directives, options, environmentVariables);
         }
     }
 }

--- a/CliFx/Services/CommandSchemaResolver.cs
+++ b/CliFx/Services/CommandSchemaResolver.cs
@@ -31,7 +31,8 @@ namespace CliFx.Services
                     attribute.Name,
                     attribute.ShortName,
                     attribute.IsRequired,
-                    attribute.Description);
+                    attribute.Description,
+					attribute.EnvironmentVariableName);
 
                 // Make sure there are no other options with the same name
                 var existingOptionWithSameName = result

--- a/CliFx/Services/CommandSchemaResolver.cs
+++ b/CliFx/Services/CommandSchemaResolver.cs
@@ -1,11 +1,11 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Reflection;
-using CliFx.Attributes;
+﻿using CliFx.Attributes;
 using CliFx.Exceptions;
 using CliFx.Internal;
 using CliFx.Models;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
 
 namespace CliFx.Services
 {
@@ -32,7 +32,7 @@ namespace CliFx.Services
                     attribute.ShortName,
                     attribute.IsRequired,
                     attribute.Description,
-					attribute.EnvironmentVariableName);
+                    attribute.EnvironmentVariableName);
 
                 // Make sure there are no other options with the same name
                 var existingOptionWithSameName = result

--- a/CliFx/Services/CommandSchemaResolver.cs
+++ b/CliFx/Services/CommandSchemaResolver.cs
@@ -1,11 +1,11 @@
-﻿using CliFx.Attributes;
-using CliFx.Exceptions;
-using CliFx.Internal;
-using CliFx.Models;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
+using CliFx.Attributes;
+using CliFx.Exceptions;
+using CliFx.Internal;
+using CliFx.Models;
 
 namespace CliFx.Services
 {

--- a/CliFx/Services/EnvironmentVariablesParser.cs
+++ b/CliFx/Services/EnvironmentVariablesParser.cs
@@ -1,0 +1,30 @@
+﻿using System.IO;
+using System.Linq;
+using CliFx.Internal;
+using CliFx.Models;
+
+namespace CliFx.Services
+{
+    /// <inheritdoct />
+    public class EnvironmentVariablesParser : IEnvironmentVariablesParser
+    {
+        /// <inheritdoct />
+        public CommandOptionInput GetCommandOptionInputFromEnvironmentVariable(string environmentVariableValue, CommandOptionSchema targetOptionSchema)
+        {
+            environmentVariableValue.GuardNotNull(nameof(environmentVariableValue));
+            targetOptionSchema.GuardNotNull(nameof(targetOptionSchema));
+
+            //If the option is not a collection do not split environment variable values
+            var optionIsCollection = targetOptionSchema.Property.PropertyType.IsCollection();
+
+            if (!optionIsCollection) return new CommandOptionInput(targetOptionSchema.EnvironmentVariableName, environmentVariableValue);
+
+            //If the option is a collection split the values using System separator, empty values are discarded
+            var environmentVariableValues = environmentVariableValue.Split(Path.PathSeparator)
+                .Where(v => !v.IsNullOrWhiteSpace())
+                .ToList();
+
+            return new CommandOptionInput(targetOptionSchema.EnvironmentVariableName, environmentVariableValues);
+        }
+    }
+}

--- a/CliFx/Services/EnvironmentVariablesProvider.cs
+++ b/CliFx/Services/EnvironmentVariablesProvider.cs
@@ -34,7 +34,8 @@ namespace CliFx.Services
         /// <inheritdoc />
         public IEnumerable<string> GetValues(string variableName)
         {
-            variableName.GuardNotNull(nameof(variableName));
+            //If variableName is null simply return nothing, this may happen if a Command has not EnvironmentVariable fallback
+            if (variableName == null) return null;
 
             try
             {

--- a/CliFx/Services/EnvironmentVariablesProvider.cs
+++ b/CliFx/Services/EnvironmentVariablesProvider.cs
@@ -1,0 +1,53 @@
+﻿using CliFx.Internal;
+using System;
+using System.Collections.Generic;
+using System.Security;
+
+namespace CliFx.Services
+{
+    /// <inheritdoc />
+    public class EnvironmentVariablesProvider : IEnvironmentVariablesProvider
+    {
+        /// <summary>
+        /// Default delimiter for multiple values
+        /// </summary>
+        public const char DEFAULT_VALUES_DELIMITER = ',';
+
+        private readonly char _valuesDelimiter;
+
+        /// <summary>
+        /// Initializes a new instance of <see cref="EnvironmentVariablesProvider"/> with the values delimiter specified
+        /// </summary>
+        public EnvironmentVariablesProvider(char valuesDelimiter)
+        {
+            _valuesDelimiter = valuesDelimiter;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of <see cref="EnvironmentVariablesProvider"/> with the default values delimiter
+        /// </summary>
+        public EnvironmentVariablesProvider()
+            : this(DEFAULT_VALUES_DELIMITER)
+        {
+        }
+
+        /// <inheritdoc />
+        public IEnumerable<string> GetValues(string variableName)
+        {
+            variableName.GuardNotNull(nameof(variableName));
+
+            try
+            {
+                string variableValue = Environment.GetEnvironmentVariable(variableName);
+
+                if (string.IsNullOrWhiteSpace(variableValue)) return null;
+
+                return variableValue.Split(_valuesDelimiter);
+            }
+            catch (SecurityException)
+            {
+                return null;
+            }
+        }
+    }
+}

--- a/CliFx/Services/EnvironmentVariablesProvider.cs
+++ b/CliFx/Services/EnvironmentVariablesProvider.cs
@@ -1,6 +1,6 @@
-﻿using CliFx.Internal;
-using System;
+﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Security;
 
 namespace CliFx.Services
@@ -32,7 +32,7 @@ namespace CliFx.Services
         }
 
         /// <inheritdoc />
-        public IEnumerable<string> GetValues(string variableName)
+        public IReadOnlyList<string> GetValues(string variableName)
         {
             //If variableName is null simply return nothing, this may happen if a Command has not EnvironmentVariable fallback
             if (variableName == null) return null;
@@ -43,7 +43,10 @@ namespace CliFx.Services
 
                 if (string.IsNullOrWhiteSpace(variableValue)) return null;
 
-                return variableValue.Split(_valuesDelimiter);
+                var values = variableValue.Split(_valuesDelimiter)
+                    .Select(v => v.Trim());
+
+                return values.ToList();
             }
             catch (SecurityException)
             {

--- a/CliFx/Services/Extensions.cs
+++ b/CliFx/Services/Extensions.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using CliFx.Internal;
 
 namespace CliFx.Services
@@ -49,6 +50,26 @@ namespace CliFx.Services
             action.GuardNotNull(nameof(action));
 
             console.WithForegroundColor(foregroundColor, () => console.WithBackgroundColor(backgroundColor, action));
+        }
+
+        /// <summary>
+        /// Gets wether a string representing an environment variable value is escaped (i.e.: surrounded by double quotation marks)
+        /// </summary>
+        public static bool IsEnvironmentVariableEscaped(this string environmentVariableValue)
+        {
+            environmentVariableValue.GuardNotNull(nameof(environmentVariableValue));
+
+            return environmentVariableValue.StartsWith("\"") && environmentVariableValue.EndsWith("\"");
+        }
+
+        /// <summary>
+        /// Gets wether the <see cref="Type"/> supplied is a collection implementing <see cref="IEnumerable{T}"/>
+        /// </summary>
+        public static bool IsCollection(this Type type)
+        {
+            type.GuardNotNull(nameof(type));
+
+            return type != typeof(string) && type.GetEnumerableUnderlyingType() != null;
         }
     }
 }

--- a/CliFx/Services/IEnvironmentVariablesParser.cs
+++ b/CliFx/Services/IEnvironmentVariablesParser.cs
@@ -1,0 +1,15 @@
+﻿using CliFx.Models;
+
+namespace CliFx.Services
+{
+    /// <summary>
+    /// Parses environment variable values
+    /// </summary>
+    public interface IEnvironmentVariablesParser
+    {
+        /// <summary>
+        /// Parse an environment variable value and converts it to a <see cref="CommandOptionInput"/> 
+        /// </summary>
+        CommandOptionInput GetCommandOptionInputFromEnvironmentVariable(string environmentVariableValue, CommandOptionSchema targetOptionSchema);
+    }
+}

--- a/CliFx/Services/IEnvironmentVariablesProvider.cs
+++ b/CliFx/Services/IEnvironmentVariablesProvider.cs
@@ -11,6 +11,6 @@ namespace CliFx.Services
         /// Returns one or more values for the environment variable provided, otherwise returns null.
         /// </summary>
         /// <remarks>If the User is not allowed to read environment variables it will return null.</remarks>
-        IEnumerable<string> GetValues(string variableName);
+        IReadOnlyList<string> GetValues(string variableName);
     }
 }

--- a/CliFx/Services/IEnvironmentVariablesProvider.cs
+++ b/CliFx/Services/IEnvironmentVariablesProvider.cs
@@ -8,9 +8,9 @@ namespace CliFx.Services
     public interface IEnvironmentVariablesProvider
     {
         /// <summary>
-        /// Returns one or more values for the environment variable provided, otherwise returns null.
+        /// Returns all the environment variables available.
         /// </summary>
-        /// <remarks>If the User is not allowed to read environment variables it will return null.</remarks>
-        IReadOnlyList<string> GetValues(string variableName);
+        /// <remarks>If the User is not allowed to read environment variables it will return an empty dictionary.</remarks>
+        IReadOnlyDictionary<string, string> GetEnvironmentVariables();
     }
 }

--- a/CliFx/Services/IEnvironmentVariablesProvider.cs
+++ b/CliFx/Services/IEnvironmentVariablesProvider.cs
@@ -1,0 +1,16 @@
+﻿using System.Collections.Generic;
+
+namespace CliFx.Services
+{
+    /// <summary>
+    /// Provides environment variable values
+    /// </summary>
+    public interface IEnvironmentVariablesProvider
+    {
+        /// <summary>
+        /// Returns one or more values for the environment variable provided, otherwise returns null.
+        /// </summary>
+        /// <remarks>If the User is not allowed to read environment variables it will return null.</remarks>
+        IEnumerable<string> GetValues(string variableName);
+    }
+}


### PR DESCRIPTION
This PR introduces support to environment variables as fallback values for command options.  

The interface `IEnvironmentVariablesProvider` has been introduced to abstract away environment variables access. Given the very general interface methods, this interface has the side effect of allowing variables to come from anywhere (e.g.: a file, Redis, a database), enabling flexibility in what can be considered an environment by an implementor.  

I decided to avoid putting all system variables on `CommandInput` and instead I decided to acces environment variables only on demand and when the name is known.    
Using `CommandInput` would have required to put **all** the env. variables on and instance of `CommandInput` because the actual environment variable names required are known only on the `CommandSchema` and every `CommandOptionSchema`. Additionally exposing all the environment variables of a system can be a security risk as they may contain secrets that could be leaked in logging. 

To access environment variables by name a `CommandOptionSchema` instance is needed in oreder to read the property `EnvironmentVariableName` which, as the name implies, contains the needed variable name.  
I decided to extend `CommandInitializer` by "inverting" the foreach loop: insteand of going through every `CommandOptionInput` the loop now goes through every `CommandOptionSchema` and in case a given schema does not have a `CommandOptionInput` environment variables are queried for values. Once values are found they are turned into a substitutive `CommandOptionInput` and processed as always.  

To allow flexibility and guarantee testability I've also extended `IApplicationBuilder` to let an user specify a custom `IEnvironmentVariablesProvider`.

There a few open points before considering this PR complete, in particular:
- What to document on README about this feature
- How help text should look like for options with env. variables support
- `SecurityException`s raised when accessing variables are ignored for now

Closes #3