### PR TITLE
Use Path.Separator in environment variables tests

### DIFF
--- a/CliFx.Tests/Services/CommandInitializerTests.cs
+++ b/CliFx.Tests/Services/CommandInitializerTests.cs
@@ -8,6 +8,7 @@ using CliFx.Models;
 using CliFx.Services;
 using CliFx.Tests.TestCommands;
 using CliFx.Tests.Stubs;
+using System.IO;
 
 namespace CliFx.Tests.Services
 {
@@ -106,7 +107,7 @@ namespace CliFx.Tests.Services
                 new EnvironmentVariableWithoutCollectionPropertyCommand(),
                 GetCommandSchema(typeof(EnvironmentVariableWithoutCollectionPropertyCommand)),
                 new CommandInput(null, new CommandOptionInput[0], EnvironmentVariablesProviderStub.EnvironmentVariables),
-                new EnvironmentVariableWithoutCollectionPropertyCommand { Option = "A;B;C;" }
+                new EnvironmentVariableWithoutCollectionPropertyCommand { Option = $"A{Path.PathSeparator}B{Path.PathSeparator}C{Path.PathSeparator}" }
             );
         }
 


### PR DESCRIPTION
This PR fixes failing tests on different Operating Systems by using `Path.PathSeparator` when arranging tests data for environment variables.