### PR TITLE
Pr/nullable

### DIFF
--- a/CliFx.Demo/Commands/BookAddCommand.cs
+++ b/CliFx.Demo/Commands/BookAddCommand.cs
@@ -15,10 +15,10 @@ namespace CliFx.Demo.Commands
         private readonly LibraryService _libraryService;
 
         [CommandArgument(0, Name = "title", IsRequired = true, Description = "Book title.")]
-        public string Title { get; set; }
+        public string Title { get; set; } = "";
 
         [CommandOption("author", 'a', IsRequired = true, Description = "Book author.")]
-        public string Author { get; set; }
+        public string Author { get; set; } = "";
 
         [CommandOption("published", 'p', Description = "Book publish date.")]
         public DateTimeOffset Published { get; set; }

--- a/CliFx.Demo/Commands/BookCommand.cs
+++ b/CliFx.Demo/Commands/BookCommand.cs
@@ -13,7 +13,7 @@ namespace CliFx.Demo.Commands
         private readonly LibraryService _libraryService;
 
         [CommandOption("title", 't', IsRequired = true, Description = "Book title.")]
-        public string Title { get; set; }
+        public string Title { get; set; } = "";
 
         public BookCommand(LibraryService libraryService)
         {

--- a/CliFx.Demo/Commands/BookRemoveCommand.cs
+++ b/CliFx.Demo/Commands/BookRemoveCommand.cs
@@ -12,7 +12,7 @@ namespace CliFx.Demo.Commands
         private readonly LibraryService _libraryService;
 
         [CommandOption("title", 't', IsRequired = true, Description = "Book title.")]
-        public string Title { get; set; }
+        public string Title { get; set; } = "";
 
         public BookRemoveCommand(LibraryService libraryService)
         {

--- a/CliFx.Tests/CliFx.Tests.csproj
+++ b/CliFx.Tests/CliFx.Tests.csproj
@@ -13,6 +13,7 @@
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="5.9.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
+    <PackageReference Include="NSubstitute" Version="4.2.1" />
     <PackageReference Include="NUnit" Version="3.12.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.15.1" />
     <PackageReference Include="coverlet.msbuild" Version="2.7.0" PrivateAssets="all" />

--- a/CliFx.Tests/Services/CommandArgumentSchemasValidatorTests.cs
+++ b/CliFx.Tests/Services/CommandArgumentSchemasValidatorTests.cs
@@ -99,8 +99,8 @@ namespace CliFx.Tests.Services
 
         private class TestCommand
         {
-            public IEnumerable<int> EnumerableProperty { get; set; }
-            public string StringProperty { get; set; }
+            public IEnumerable<int> EnumerableProperty { get; set; } = new int[0];
+            public string StringProperty { get; set; } = "";
         }
 
         public class ValidatorTest

--- a/CliFx.Tests/Services/CommandFactoryTests.cs
+++ b/CliFx.Tests/Services/CommandFactoryTests.cs
@@ -12,7 +12,7 @@ namespace CliFx.Tests.Services
     [TestFixture]
     public class CommandFactoryTests
     {
-        private static CommandSchema GetCommandSchema(Type commandType) =>
+        private static ICommandSchema GetCommandSchema(Type commandType) =>
             new CommandSchemaResolver(new CommandArgumentSchemasValidator()).GetCommandSchemas(new[] {commandType}).Single();
 
         private static IEnumerable<TestCaseData> GetTestCases_CreateCommand()

--- a/CliFx.Tests/Services/CommandInitializerTests.cs
+++ b/CliFx.Tests/Services/CommandInitializerTests.cs
@@ -15,7 +15,7 @@ namespace CliFx.Tests.Services
     [TestFixture]
     public class CommandInitializerTests
     {
-        private static CommandSchema GetCommandSchema(Type commandType) =>
+        private static ICommandSchema GetCommandSchema(Type commandType) =>
             new CommandSchemaResolver(new CommandArgumentSchemasValidator()).GetCommandSchemas(new[] { commandType }).Single();
 
         private static IEnumerable<TestCaseData> GetTestCases_InitializeCommand()

--- a/CliFx.Tests/Services/CommandSchemaResolverTests.cs
+++ b/CliFx.Tests/Services/CommandSchemaResolverTests.cs
@@ -6,6 +6,7 @@ using CliFx.Exceptions;
 using CliFx.Models;
 using CliFx.Services;
 using CliFx.Tests.TestCommands;
+using NSubstitute;
 
 namespace CliFx.Tests.Services
 {
@@ -93,9 +94,9 @@ namespace CliFx.Tests.Services
             yield return new TestCaseData(
                 new []
                 {
-                    new CommandSchema(null, "command1", null, null, null),
-                    new CommandSchema(null, "command2", null, null, null),
-                    new CommandSchema(null, "command3", null, null, null)
+                    GetSchemaWithName("command1"),
+                    GetSchemaWithName("command2"),
+                    GetSchemaWithName("command3")
                 },
                 new CommandInput(new[] { "command1", "argument1", "argument2" }),
                 new[] { "argument1", "argument2" },
@@ -104,10 +105,10 @@ namespace CliFx.Tests.Services
             yield return new TestCaseData(
                 new []
                 {
-                    new CommandSchema(null, "", null, null, null),
-                    new CommandSchema(null, "command1", null, null, null),
-                    new CommandSchema(null, "command2", null, null, null),
-                    new CommandSchema(null, "command3", null, null, null)
+                    GetSchemaWithName(""),
+                    GetSchemaWithName("command1"),
+                    GetSchemaWithName("command2"),
+                    GetSchemaWithName("command3")
                 },
                 new CommandInput(new[] { "argument1", "argument2" }),
                 new[] { "argument1", "argument2" },
@@ -116,7 +117,7 @@ namespace CliFx.Tests.Services
             yield return new TestCaseData(
                 new []
                 {
-                    new CommandSchema(null, "command1 subcommand1", null, null, null),
+                    GetSchemaWithName("command1 subcommand1"),
                 },
                 new CommandInput(new[] { "command1", "subcommand1", "argument1" }),
                 new[] { "argument1" },
@@ -125,13 +126,13 @@ namespace CliFx.Tests.Services
             yield return new TestCaseData(
                 new []
                 {
-                    new CommandSchema(null, "", null, null, null),
-                    new CommandSchema(null, "a", null, null, null),
-                    new CommandSchema(null, "a b", null, null, null),
-                    new CommandSchema(null, "a b c", null, null, null),
-                    new CommandSchema(null, "b", null, null, null),
-                    new CommandSchema(null, "b c", null, null, null),
-                    new CommandSchema(null, "c", null, null, null),
+                    GetSchemaWithName(""),
+                    GetSchemaWithName("a"),
+                    GetSchemaWithName("a b"),
+                    GetSchemaWithName("a b c"),
+                    GetSchemaWithName("b"),
+                    GetSchemaWithName("b c"),
+                    GetSchemaWithName("c"),
                 },
                 new CommandInput(new[] { "a", "b", "d" }),
                 new[] { "d" },
@@ -140,13 +141,13 @@ namespace CliFx.Tests.Services
             yield return new TestCaseData(
                 new []
                 {
-                    new CommandSchema(null, "", null, null, null),
-                    new CommandSchema(null, "a", null, null, null),
-                    new CommandSchema(null, "a b", null, null, null),
-                    new CommandSchema(null, "a b c", null, null, null),
-                    new CommandSchema(null, "b", null, null, null),
-                    new CommandSchema(null, "b c", null, null, null),
-                    new CommandSchema(null, "c", null, null, null),
+                    GetSchemaWithName(""),
+                    GetSchemaWithName("a"),
+                    GetSchemaWithName("a b"),
+                    GetSchemaWithName("a b c"),
+                    GetSchemaWithName("b"),
+                    GetSchemaWithName("b c"),
+                    GetSchemaWithName("c"),
                 },
                 new CommandInput(new[] { "a", "b", "c", "d" }),
                 new[] { "d" },
@@ -155,13 +156,13 @@ namespace CliFx.Tests.Services
             yield return new TestCaseData(
                 new []
                 {
-                    new CommandSchema(null, "", null, null, null),
-                    new CommandSchema(null, "a", null, null, null),
-                    new CommandSchema(null, "a b", null, null, null),
-                    new CommandSchema(null, "a b c", null, null, null),
-                    new CommandSchema(null, "b", null, null, null),
-                    new CommandSchema(null, "b c", null, null, null),
-                    new CommandSchema(null, "c", null, null, null),
+                    GetSchemaWithName(""),
+                    GetSchemaWithName("a"),
+                    GetSchemaWithName("a b"),
+                    GetSchemaWithName("a b c"),
+                    GetSchemaWithName("b"),
+                    GetSchemaWithName("b c"),
+                    GetSchemaWithName("c"),
                 },
                 new CommandInput(new[] { "b", "c" }),
                 new string[0],
@@ -170,13 +171,13 @@ namespace CliFx.Tests.Services
             yield return new TestCaseData(
                 new []
                 {
-                    new CommandSchema(null, "", null, null, null),
-                    new CommandSchema(null, "a", null, null, null),
-                    new CommandSchema(null, "a b", null, null, null),
-                    new CommandSchema(null, "a b c", null, null, null),
-                    new CommandSchema(null, "b", null, null, null),
-                    new CommandSchema(null, "b c", null, null, null),
-                    new CommandSchema(null, "c", null, null, null),
+                    GetSchemaWithName(""),
+                    GetSchemaWithName("a"),
+                    GetSchemaWithName("a b"),
+                    GetSchemaWithName("a b c"),
+                    GetSchemaWithName("b"),
+                    GetSchemaWithName("b c"),
+                    GetSchemaWithName("c"),
                 },
                 new CommandInput(new[] { "d", "a", "b"}),
                 new[] { "d", "a", "b" },
@@ -185,13 +186,13 @@ namespace CliFx.Tests.Services
             yield return new TestCaseData(
                 new []
                 {
-                    new CommandSchema(null, "", null, null, null),
-                    new CommandSchema(null, "a", null, null, null),
-                    new CommandSchema(null, "a b", null, null, null),
-                    new CommandSchema(null, "a b c", null, null, null),
-                    new CommandSchema(null, "b", null, null, null),
-                    new CommandSchema(null, "b c", null, null, null),
-                    new CommandSchema(null, "c", null, null, null),
+                    GetSchemaWithName(""),
+                    GetSchemaWithName("a"),
+                    GetSchemaWithName("a b"),
+                    GetSchemaWithName("a b c"),
+                    GetSchemaWithName("b"),
+                    GetSchemaWithName("b c"),
+                    GetSchemaWithName("c"),
                 },
                 new CommandInput(new[] { "a", "b c", "d" }),
                 new[] { "b c", "d" },
@@ -200,13 +201,13 @@ namespace CliFx.Tests.Services
             yield return new TestCaseData(
                 new []
                 {
-                    new CommandSchema(null, "", null, null, null),
-                    new CommandSchema(null, "a", null, null, null),
-                    new CommandSchema(null, "a b", null, null, null),
-                    new CommandSchema(null, "a b c", null, null, null),
-                    new CommandSchema(null, "b", null, null, null),
-                    new CommandSchema(null, "b c", null, null, null),
-                    new CommandSchema(null, "c", null, null, null),
+                    GetSchemaWithName(""),
+                    GetSchemaWithName("a"),
+                    GetSchemaWithName("a b"),
+                    GetSchemaWithName("a b c"),
+                    GetSchemaWithName("b"),
+                    GetSchemaWithName("b c"),
+                    GetSchemaWithName("c"),
                 },
                 new CommandInput(new[] { "a b", "c", "d" }),
                 new[] { "a b", "c", "d" },
@@ -219,25 +220,25 @@ namespace CliFx.Tests.Services
             yield return new TestCaseData(
                 new []
                 {
-                    new CommandSchema(null, "command1", null, null, null),
-                    new CommandSchema(null, "command2", null, null, null),
-                    new CommandSchema(null, "command3", null, null, null),
+                    GetSchemaWithName("command1"),
+                    GetSchemaWithName("command2"),
+                    GetSchemaWithName("command3"),
                 },
                 new CommandInput(new[] { "command4", "argument1" })
             );
             yield return new TestCaseData(
                 new []
                 {
-                    new CommandSchema(null, "command1", null, null, null),
-                    new CommandSchema(null, "command2", null, null, null),
-                    new CommandSchema(null, "command3", null, null, null),
+                    GetSchemaWithName("command1"),
+                    GetSchemaWithName("command2"),
+                    GetSchemaWithName("command3"),
                 },
                 new CommandInput(new[] { "argument1" })
             );
             yield return new TestCaseData(
                 new []
                 {
-                    new CommandSchema(null, "command1 subcommand1", null, null, null),
+                    GetSchemaWithName("command1 subcommand1"),
                 },
                 new CommandInput(new[] { "command1", "argument1" })
             );
@@ -272,7 +273,7 @@ namespace CliFx.Tests.Services
 
         [Test]
         [TestCaseSource(nameof(GetTestCases_GetTargetCommandSchema_Positive))]
-        public void GetTargetCommandSchema_Positive_Test(IReadOnlyList<CommandSchema> availableCommandSchemas,
+        public void GetTargetCommandSchema_Positive_Test(IReadOnlyList<ICommandSchema> availableCommandSchemas,
             CommandInput commandInput,
             IReadOnlyList<string> expectedPositionalArguments,
             string expectedCommandSchemaName)
@@ -285,13 +286,13 @@ namespace CliFx.Tests.Services
 
             // Assert
             commandCandidate.Should().NotBeNull();
-            commandCandidate.PositionalArgumentsInput.Should().BeEquivalentTo(expectedPositionalArguments);
-            commandCandidate.Schema.Name.Should().Be(expectedCommandSchemaName);
+            commandCandidate!.PositionalArgumentsInput.Should().BeEquivalentTo(expectedPositionalArguments);
+            commandCandidate!.Schema.Name.Should().Be(expectedCommandSchemaName);
         }
 
         [Test]
         [TestCaseSource(nameof(GetTestCases_GetTargetCommandSchema_Negative))]
-        public void GetTargetCommandSchema_Negative_Test(IReadOnlyList<CommandSchema> availableCommandSchemas, CommandInput commandInput)
+        public void GetTargetCommandSchema_Negative_Test(IReadOnlyList<ICommandSchema> availableCommandSchemas, CommandInput commandInput)
         {
             // Arrange
             var resolver = new CommandSchemaResolver(new CommandArgumentSchemasValidator());
@@ -301,6 +302,13 @@ namespace CliFx.Tests.Services
 
             // Assert
             commandCandidate.Should().BeNull();
+        }
+
+        private static ICommandSchema GetSchemaWithName(string? name)
+        {
+            var schema = Substitute.For<ICommandSchema>();
+            schema.Name.Returns(name);
+            return schema;
         }
     }
 }

--- a/CliFx.Tests/Services/DelegateCommandFactoryTests.cs
+++ b/CliFx.Tests/Services/DelegateCommandFactoryTests.cs
@@ -12,20 +12,20 @@ namespace CliFx.Tests.Services
     [TestFixture]
     public class DelegateCommandFactoryTests
     {
-        private static CommandSchema GetCommandSchema(Type commandType) =>
+        private static ICommandSchema GetCommandSchema(Type commandType) =>
             new CommandSchemaResolver(new CommandArgumentSchemasValidator()).GetCommandSchemas(new[] {commandType}).Single();
 
         private static IEnumerable<TestCaseData> GetTestCases_CreateCommand()
         {
             yield return new TestCaseData(
-                new Func<CommandSchema, ICommand>(schema => (ICommand) Activator.CreateInstance(schema.Type!)!),
+                new Func<ICommandSchema, ICommand>(schema => (ICommand) Activator.CreateInstance(schema.Type)!),
                 GetCommandSchema(typeof(HelloWorldDefaultCommand))
             );
         }
 
         [Test]
         [TestCaseSource(nameof(GetTestCases_CreateCommand))]
-        public void CreateCommand_Test(Func<CommandSchema, ICommand> factoryMethod, CommandSchema commandSchema)
+        public void CreateCommand_Test(Func<ICommandSchema, ICommand> factoryMethod, ICommandSchema commandSchema)
         {
             // Arrange
             var factory = new DelegateCommandFactory(factoryMethod);

--- a/CliFx.Tests/TestCommands/ArgumentCommand.cs
+++ b/CliFx.Tests/TestCommands/ArgumentCommand.cs
@@ -15,10 +15,10 @@ namespace CliFx.Tests.TestCommands
         public int? SecondArgument { get; set; }
         
         [CommandArgument(20, Description = "A list of numbers", Name = "third list")]
-        public IEnumerable<int> ThirdArguments { get; set; }
+        public IEnumerable<int>? ThirdArguments { get; set; }
         
         [CommandOption("option", 'o')]
-        public string Option { get; set; }
+        public string? Option { get; set; }
 
         public ValueTask ExecuteAsync(IConsole console) => default;
     }

--- a/CliFx.Tests/TestCommands/ConcatCommand.cs
+++ b/CliFx.Tests/TestCommands/ConcatCommand.cs
@@ -9,7 +9,7 @@ namespace CliFx.Tests.TestCommands
     public class ConcatCommand : ICommand
     {
         [CommandOption('i', IsRequired = true, Description = "Input strings.")]
-        public IReadOnlyList<string> Inputs { get; set; }
+        public IReadOnlyList<string> Inputs { get; set; } = new string[0];
 
         [CommandOption('s', Description = "String separator.")]
         public string Separator { get; set; } = ""; 

--- a/CliFx.Tests/TestCommands/SimpleArgumentCommand.cs
+++ b/CliFx.Tests/TestCommands/SimpleArgumentCommand.cs
@@ -12,9 +12,9 @@ namespace CliFx.Tests.TestCommands
         
         [CommandArgument(10)]
         public int? SecondArgument { get; set; }
-        
-        [CommandOption("option", 'o')]
-        public string Option { get; set; }
+
+        [CommandOption("option", 'o')] 
+        public string? Option { get; set; }
 
         public ValueTask ExecuteAsync(IConsole console) => default;
     }

--- a/CliFx/CliApplication.cs
+++ b/CliFx/CliApplication.cs
@@ -115,7 +115,7 @@ namespace CliFx
         }
 
         private int? HandleHelpOption(CommandInput commandInput,
-            IReadOnlyList<CommandSchema> availableCommandSchemas, CommandCandidate? commandCandidate)
+            IReadOnlyList<ICommandSchema> availableCommandSchemas, CommandCandidate? commandCandidate)
         {
             // Help should be rendered if it was requested, or when executing a command which isn't defined
             var shouldRenderHelp = commandInput.IsHelpOptionSpecified() || commandCandidate == null;
@@ -127,8 +127,10 @@ namespace CliFx
             // Keep track whether there was an error in the input
             var isError = false;
 
+            ICommandSchema? commandSchema = commandCandidate?.Schema;
+
             // Report error if no command matched the arguments
-            if (commandCandidate is null)
+            if (commandSchema is null)
             {
                 // If a command was specified, inform the user that the command is not defined
                 if (commandInput.HasArguments())
@@ -137,12 +139,10 @@ namespace CliFx
                         () => _console.Error.WriteLine($"No command could be matched for input [{string.Join(" ", commandInput.Arguments)}]"));
                     isError = true;
                 }
-
-                commandCandidate = new CommandCandidate(CommandSchema.StubDefaultCommand, new string[0], commandInput);
             }
 
             // Build help text source
-            var helpTextSource = new HelpTextSource(_metadata, availableCommandSchemas, commandCandidate.Schema);
+            var helpTextSource = new HelpTextSource(_metadata, availableCommandSchemas, commandSchema);
 
             // Render help text
             _helpTextRenderer.RenderHelpText(_console, helpTextSource);

--- a/CliFx/Extensions.cs
+++ b/CliFx/Extensions.cs
@@ -42,7 +42,7 @@ namespace CliFx
         /// <summary>
         /// Configures application to use specified factory method for creating new instances of <see cref="ICommand"/>.
         /// </summary>
-        public static ICliApplicationBuilder UseCommandFactory(this ICliApplicationBuilder builder, Func<CommandSchema, ICommand> factoryMethod) =>
+        public static ICliApplicationBuilder UseCommandFactory(this ICliApplicationBuilder builder, Func<ICommandSchema, ICommand> factoryMethod) =>
             builder.UseCommandFactory(new DelegateCommandFactory(factoryMethod));
     }
 }

--- a/CliFx/Models/CommandCandidate.cs
+++ b/CliFx/Models/CommandCandidate.cs
@@ -10,7 +10,7 @@ namespace CliFx.Models
         /// <summary>
         /// The command schema of the target command.
         /// </summary>
-        public CommandSchema Schema { get; }
+        public ICommandSchema Schema { get; }
 
         /// <summary>
         /// The positional arguments input for the command.
@@ -25,7 +25,7 @@ namespace CliFx.Models
         /// <summary>
         /// Initializes and instance of <see cref="CommandCandidate"/>
         /// </summary>
-        public CommandCandidate(CommandSchema schema, IReadOnlyList<string> positionalArgumentsInput, CommandInput commandInput)
+        public CommandCandidate(ICommandSchema schema, IReadOnlyList<string> positionalArgumentsInput, CommandInput commandInput)
         {
             Schema = schema;
             PositionalArgumentsInput = positionalArgumentsInput;

--- a/CliFx/Models/CommandSchema.cs
+++ b/CliFx/Models/CommandSchema.cs
@@ -5,40 +5,28 @@ using CliFx.Internal;
 
 namespace CliFx.Models
 {
-    /// <summary>
-    /// Schema of a defined command.
-    /// </summary>
-    public partial class CommandSchema
+    /// <inheritdoc />
+    public partial class CommandSchema : ICommandSchema
     {
-        /// <summary>
-        /// Underlying type.
-        /// </summary>
-        public Type? Type { get; }
+        /// <inheritdoc />
+        public Type Type { get; }
 
-        /// <summary>
-        /// Command name.
-        /// </summary>
+        /// <inheritdoc />
         public string? Name { get; }
 
-        /// <summary>
-        /// Command description.
-        /// </summary>
+        /// <inheritdoc />
         public string? Description { get; }
 
-        /// <summary>
-        /// Command options.
-        /// </summary>
+        /// <inheritdoc />
         public IReadOnlyList<CommandOptionSchema> Options { get; }
 
-        /// <summary>
-        /// Command arguments.
-        /// </summary>
+        /// <inheritdoc />
         public IReadOnlyList<CommandArgumentSchema> Arguments { get; }
 
         /// <summary>
         /// Initializes an instance of <see cref="CommandSchema"/>.
         /// </summary>
-        public CommandSchema(Type type, string name, string description, IReadOnlyList<CommandArgumentSchema> arguments, IReadOnlyList<CommandOptionSchema> options)
+        public CommandSchema(Type type, string? name, string? description, IReadOnlyList<CommandArgumentSchema> arguments, IReadOnlyList<CommandOptionSchema> options)
         {
             Type = type;
             Name = name;
@@ -65,11 +53,5 @@ namespace CliFx.Models
 
             return buffer.ToString();
         }
-    }
-
-    public partial class CommandSchema
-    {
-        internal static CommandSchema StubDefaultCommand { get; } =
-            new CommandSchema(null, null, null, new CommandArgumentSchema[0], new CommandOptionSchema[0]);
     }
 }

--- a/CliFx/Models/Extensions.cs
+++ b/CliFx/Models/Extensions.cs
@@ -14,7 +14,7 @@ namespace CliFx.Models
         /// <summary>
         /// Finds a command that has specified name, or null if not found.
         /// </summary>
-        public static CommandSchema? FindByName(this IReadOnlyList<CommandSchema> commandSchemas, string? commandName)
+        public static ICommandSchema? FindByName(this IReadOnlyList<ICommandSchema> commandSchemas, string? commandName)
         {
             // If looking for default command, don't compare names directly
             // ...because null and empty are both valid names for default command
@@ -27,14 +27,14 @@ namespace CliFx.Models
         /// <summary>
         /// Finds parent command to the command that has specified name, or null if not found.
         /// </summary>
-        public static CommandSchema? FindParent(this IReadOnlyList<CommandSchema> commandSchemas, string? commandName)
+        public static ICommandSchema? FindParent(this IReadOnlyList<ICommandSchema> commandSchemas, string? commandName)
         {
             // If command has no name, it's the default command so it doesn't have a parent
             if (string.IsNullOrWhiteSpace(commandName))
                 return null;
 
             // Repeatedly cut off individual words from the name until we find a command with that name
-            var temp = commandName;
+            var temp = commandName!;
             while (temp.Contains(" "))
             {
                 temp = temp.SubstringUntilLast(" ");
@@ -126,6 +126,6 @@ namespace CliFx.Models
         /// <summary>
         /// Gets whether this command is the default command, i.e. without a name.
         /// </summary>
-        public static bool IsDefault(this CommandSchema commandSchema) => string.IsNullOrWhiteSpace(commandSchema.Name);
+        public static bool IsDefault(this ICommandSchema? commandSchema) => string.IsNullOrWhiteSpace(commandSchema?.Name);
     }
 }

--- a/CliFx/Models/HelpTextSource.cs
+++ b/CliFx/Models/HelpTextSource.cs
@@ -15,19 +15,19 @@ namespace CliFx.Models
         /// <summary>
         /// Schemas of commands available in the application.
         /// </summary>
-        public IReadOnlyList<CommandSchema> AvailableCommandSchemas { get; }
+        public IReadOnlyList<ICommandSchema> AvailableCommandSchemas { get; }
 
         /// <summary>
         /// Schema of the command for which help text is to be generated.
         /// </summary>
-        public CommandSchema TargetCommandSchema { get; }
+        public ICommandSchema? TargetCommandSchema { get; }
 
         /// <summary>
         /// Initializes an instance of <see cref="HelpTextSource"/>.
         /// </summary>
         public HelpTextSource(ApplicationMetadata applicationMetadata,
-            IReadOnlyList<CommandSchema> availableCommandSchemas,
-            CommandSchema targetCommandSchema)
+            IReadOnlyList<ICommandSchema> availableCommandSchemas,
+            ICommandSchema? targetCommandSchema)
         {
             ApplicationMetadata = applicationMetadata;
             AvailableCommandSchemas = availableCommandSchemas;

--- a/CliFx/Models/ICommandSchema.cs
+++ b/CliFx/Models/ICommandSchema.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace CliFx.Models
+{
+    /// <summary>
+    /// Schema of a defined command.
+    /// </summary>
+    public interface ICommandSchema
+    {
+        /// <summary>
+        /// Underlying type.
+        /// </summary>
+        Type Type { get; }
+
+        /// <summary>
+        /// Command name.
+        /// </summary>
+        string? Name { get; }
+
+        /// <summary>
+        /// Command description.
+        /// </summary>
+        string? Description { get; }
+
+        /// <summary>
+        /// Command options.
+        /// </summary>
+        IReadOnlyList<CommandOptionSchema> Options { get; }
+
+        /// <summary>
+        /// Command arguments.
+        /// </summary>
+        IReadOnlyList<CommandArgumentSchema> Arguments { get; }
+    }
+}

--- a/CliFx/Services/CommandFactory.cs
+++ b/CliFx/Services/CommandFactory.cs
@@ -9,6 +9,6 @@ namespace CliFx.Services
     public class CommandFactory : ICommandFactory
     {
         /// <inheritdoc />
-        public ICommand CreateCommand(CommandSchema commandSchema) => (ICommand) Activator.CreateInstance(commandSchema.Type);
+        public ICommand CreateCommand(ICommandSchema commandSchema) => (ICommand) Activator.CreateInstance(commandSchema.Type);
     }
 }

--- a/CliFx/Services/CommandInitializer.cs
+++ b/CliFx/Services/CommandInitializer.cs
@@ -69,7 +69,7 @@ namespace CliFx.Services
                     if (!fallbackEnvironmentVariableExists || string.IsNullOrWhiteSpace(commandCandidate.CommandInput.EnvironmentVariables[optionSchema.EnvironmentVariableName!]))
                         continue;
 
-                    optionInput = _environmentVariablesParser.GetCommandOptionInputFromEnvironmentVariable(commandCandidate.CommandInput.EnvironmentVariables[optionSchema.EnvironmentVariableName!], optionSchema);
+                    optionInput = _environmentVariablesParser.GetCommandOptionInputFromEnvironmentVariable(optionSchema.EnvironmentVariableName!, commandCandidate.CommandInput.EnvironmentVariables[optionSchema.EnvironmentVariableName!], optionSchema);
                 }
 
                 //No fallback available and no option input was specified, skip option

--- a/CliFx/Services/CommandSchemaResolver.cs
+++ b/CliFx/Services/CommandSchemaResolver.cs
@@ -97,7 +97,7 @@ namespace CliFx.Services
         }
 
         /// <inheritdoc />
-        public IReadOnlyList<CommandSchema> GetCommandSchemas(IReadOnlyList<Type> commandTypes)
+        public IReadOnlyList<ICommandSchema> GetCommandSchemas(IReadOnlyList<Type> commandTypes)
         {
             // Make sure there's at least one command defined
             if (!commandTypes.Any())
@@ -107,7 +107,7 @@ namespace CliFx.Services
                     "An application needs to have at least one command to work.");
             }
 
-            var result = new List<CommandSchema>();
+            var result = new List<ICommandSchema>();
 
             foreach (var commandType in commandTypes)
             {
@@ -165,10 +165,10 @@ namespace CliFx.Services
         }
 
         /// <inheritdoc />
-        public CommandCandidate? GetTargetCommandSchema(IReadOnlyList<CommandSchema> availableCommandSchemas, CommandInput commandInput)
+        public CommandCandidate? GetTargetCommandSchema(IReadOnlyList<ICommandSchema> availableCommandSchemas, CommandInput commandInput)
         {
             // If no arguments are given, use the default command
-            CommandSchema targetSchema;
+            ICommandSchema targetSchema;
             if (!commandInput.Arguments.Any())
             {
                 targetSchema = availableCommandSchemas.FirstOrDefault(c => c.IsDefault());

--- a/CliFx/Services/DelegateCommandFactory.cs
+++ b/CliFx/Services/DelegateCommandFactory.cs
@@ -8,17 +8,17 @@ namespace CliFx.Services
     /// </summary>
     public class DelegateCommandFactory : ICommandFactory
     {
-        private readonly Func<CommandSchema, ICommand> _factoryMethod;
+        private readonly Func<ICommandSchema, ICommand> _factoryMethod;
 
         /// <summary>
         /// Initializes an instance of <see cref="DelegateCommandFactory"/>.
         /// </summary>
-        public DelegateCommandFactory(Func<CommandSchema, ICommand> factoryMethod)
+        public DelegateCommandFactory(Func<ICommandSchema, ICommand> factoryMethod)
         {
             _factoryMethod = factoryMethod;
         }
 
         /// <inheritdoc />
-        public ICommand CreateCommand(CommandSchema commandSchema) => _factoryMethod(commandSchema);
+        public ICommand CreateCommand(ICommandSchema commandSchema) => _factoryMethod(commandSchema);
     }
 }

--- a/CliFx/Services/EnvironmentVariablesParser.cs
+++ b/CliFx/Services/EnvironmentVariablesParser.cs
@@ -9,19 +9,19 @@ namespace CliFx.Services
     public class EnvironmentVariablesParser : IEnvironmentVariablesParser
     {
         /// <inheritdoct />
-        public CommandOptionInput GetCommandOptionInputFromEnvironmentVariable(string environmentVariableValue, CommandOptionSchema targetOptionSchema)
+        public CommandOptionInput GetCommandOptionInputFromEnvironmentVariable(string environmentVariableName, string environmentVariableValue, CommandOptionSchema targetOptionSchema)
         {
             //If the option is not a collection do not split environment variable values
             var optionIsCollection = targetOptionSchema.Property != null && targetOptionSchema.Property.PropertyType.IsCollection();
 
-            if (!optionIsCollection) return new CommandOptionInput(targetOptionSchema.EnvironmentVariableName, environmentVariableValue);
+            if (!optionIsCollection) return new CommandOptionInput(environmentVariableName, environmentVariableValue);
 
             //If the option is a collection split the values using System separator, empty values are discarded
             var environmentVariableValues = environmentVariableValue.Split(Path.PathSeparator)
                 .Where(v => !string.IsNullOrWhiteSpace(v))
                 .ToList();
 
-            return new CommandOptionInput(targetOptionSchema.EnvironmentVariableName, environmentVariableValues);
+            return new CommandOptionInput(environmentVariableName, environmentVariableValues);
         }
     }
 }

--- a/CliFx/Services/HelpTextRenderer.cs
+++ b/CliFx/Services/HelpTextRenderer.cs
@@ -111,7 +111,7 @@ namespace CliFx.Services
 
             void RenderDescription()
             {
-                if (string.IsNullOrWhiteSpace(source.TargetCommandSchema.Description))
+                if (string.IsNullOrWhiteSpace(source.TargetCommandSchema?.Description))
                     return;
 
                 // Margin
@@ -122,7 +122,7 @@ namespace CliFx.Services
 
                 // Description
                 RenderIndent();
-                Render(source.TargetCommandSchema.Description!);
+                Render(source.TargetCommandSchema!.Description!);
                 RenderNewLine();
             }
 
@@ -139,10 +139,10 @@ namespace CliFx.Services
                 Render(source.ApplicationMetadata.ExecutableName);
 
                 // Command name
-                if (!string.IsNullOrWhiteSpace(source.TargetCommandSchema.Name))
+                if (!string.IsNullOrWhiteSpace(source.TargetCommandSchema?.Name))
                 {
                     Render(" ");
-                    RenderWithColor(source.TargetCommandSchema.Name!, ConsoleColor.Cyan);
+                    RenderWithColor(source.TargetCommandSchema!.Name!, ConsoleColor.Cyan);
                 }
 
                 // Child command
@@ -153,17 +153,21 @@ namespace CliFx.Services
                 }
 
                 // Arguments
-                foreach (var argumentSchema in source.TargetCommandSchema.Arguments)
+                if (source.TargetCommandSchema != null)
                 {
-                    Render(" ");
-                    if (!argumentSchema.IsRequired)
-                        Render("[");
+                    foreach (var argumentSchema in source.TargetCommandSchema.Arguments)
+                    {
+                        Render(" ");
+                        if (!argumentSchema.IsRequired)
+                            Render("[");
 
-                    Render($"<{argumentSchema.DisplayName}>");
+                        Render($"<{argumentSchema.DisplayName}>");
 
-                    if (!argumentSchema.IsRequired)
-                        Render("]");
+                        if (!argumentSchema.IsRequired)
+                            Render("]");
+                    }
                 }
+
 
                 // Options
                 Render(" ");
@@ -174,7 +178,7 @@ namespace CliFx.Services
             void RenderArguments()
             {
                 // Do not render anything if the command has no arguments
-                if (source.TargetCommandSchema.Arguments.Count == 0)
+                if (source.TargetCommandSchema is null || source.TargetCommandSchema.Arguments.Count  == 0)
                     return;
 
                 // Margin
@@ -224,7 +228,7 @@ namespace CliFx.Services
                 RenderHeader("Options");
 
                 // Order options and append built-in options
-                var allOptionSchemas = source.TargetCommandSchema.Options
+                var allOptionSchemas = (source.TargetCommandSchema?.Options ?? Enumerable.Empty<CommandOptionSchema>())
                     .OrderByDescending(o => o.IsRequired)
                     .Concat(builtInOptionSchemas)
                     .ToArray();
@@ -308,10 +312,10 @@ namespace CliFx.Services
                 Render("You can run `");
                 Render(source.ApplicationMetadata.ExecutableName);
 
-                if (!string.IsNullOrWhiteSpace(source.TargetCommandSchema.Name))
+                if (!string.IsNullOrWhiteSpace(source.TargetCommandSchema?.Name))
                 {
                     Render(" ");
-                    RenderWithColor(source.TargetCommandSchema.Name, ConsoleColor.Cyan);
+                    RenderWithColor(source.TargetCommandSchema!.Name!, ConsoleColor.Cyan);
                 }
 
                 Render(" ");
@@ -340,9 +344,9 @@ namespace CliFx.Services
 
     public partial class HelpTextRenderer
     {
-        private static string? GetRelativeCommandName(CommandSchema commandSchema, CommandSchema parentCommandSchema) =>
-            string.IsNullOrWhiteSpace(parentCommandSchema.Name) || string.IsNullOrWhiteSpace(commandSchema.Name)
+        private static string? GetRelativeCommandName(ICommandSchema commandSchema, ICommandSchema? parentCommandSchema) =>
+            string.IsNullOrWhiteSpace(parentCommandSchema?.Name) || string.IsNullOrWhiteSpace(commandSchema.Name)
                 ? commandSchema.Name
-                : commandSchema.Name!.Substring(parentCommandSchema.Name!.Length + 1);
+                : commandSchema.Name!.Substring(parentCommandSchema!.Name!.Length + 1);
     }
 }

--- a/CliFx/Services/ICommandFactory.cs
+++ b/CliFx/Services/ICommandFactory.cs
@@ -10,6 +10,6 @@ namespace CliFx.Services
         /// <summary>
         /// Initializes an instance of <see cref="ICommand"/> with specified schema.
         /// </summary>
-        ICommand CreateCommand(CommandSchema commandSchema);
+        ICommand CreateCommand(ICommandSchema commandSchema);
     }
 }

--- a/CliFx/Services/ICommandSchemaResolver.cs
+++ b/CliFx/Services/ICommandSchemaResolver.cs
@@ -12,11 +12,11 @@ namespace CliFx.Services
         /// <summary>
         /// Resolves schemas of specified command types.
         /// </summary>
-        IReadOnlyList<CommandSchema> GetCommandSchemas(IReadOnlyList<Type> commandTypes);
+        IReadOnlyList<ICommandSchema> GetCommandSchemas(IReadOnlyList<Type> commandTypes);
 
         /// <summary>
         /// Get the target command schema. The target command is the most specific command that matches the unbound input arguments.
         /// </summary>
-        CommandCandidate? GetTargetCommandSchema(IReadOnlyList<CommandSchema> availableCommandSchemas, CommandInput commandInput);
+        CommandCandidate? GetTargetCommandSchema(IReadOnlyList<ICommandSchema> availableCommandSchemas, CommandInput commandInput);
     }
 }

--- a/CliFx/Services/IEnvironmentVariablesParser.cs
+++ b/CliFx/Services/IEnvironmentVariablesParser.cs
@@ -10,6 +10,6 @@ namespace CliFx.Services
         /// <summary>
         /// Parse an environment variable value and converts it to a <see cref="CommandOptionInput"/> 
         /// </summary>
-        CommandOptionInput GetCommandOptionInputFromEnvironmentVariable(string environmentVariableValue, CommandOptionSchema targetOptionSchema);
+        CommandOptionInput GetCommandOptionInputFromEnvironmentVariable(string environmentVariableName, string environmentVariableValue, CommandOptionSchema targetOptionSchema);
     }
 }


### PR DESCRIPTION
This PR should eliminate all warnings related to nullable reference types. It does have some structual changes in that it introduces an `ICommandSchema` interface and a mocking framework (NSubstitute) for the test project.