### PR TITLE
Add ability to specify active debugger attachment instead of passive

### DIFF
--- a/CliFx/ApplicationConfiguration.cs
+++ b/CliFx/ApplicationConfiguration.cs
@@ -17,22 +17,30 @@ namespace CliFx
         /// Whether debug mode is allowed in this application.
         /// </summary>
         public bool IsDebugModeAllowed { get; }
-
+        
         /// <summary>
         /// Whether preview mode is allowed in this application.
         /// </summary>
         public bool IsPreviewModeAllowed { get; }
 
         /// <summary>
+        /// Prompt debugger launch when application is in debug mode
+        /// </summary>
+        public bool PromptDebuggerLaunchInDebugMode { get; }
+
+        /// <summary>
         /// Initializes an instance of <see cref="ApplicationConfiguration"/>.
         /// </summary>
         public ApplicationConfiguration(
             IReadOnlyList<Type> commandTypes,
-            bool isDebugModeAllowed, bool isPreviewModeAllowed)
+            bool isDebugModeAllowed, 
+            bool isPreviewModeAllowed, 
+            bool promptDebuggerLaunchInDebugMode)
         {
             CommandTypes = commandTypes;
             IsDebugModeAllowed = isDebugModeAllowed;
             IsPreviewModeAllowed = isPreviewModeAllowed;
+            PromptDebuggerLaunchInDebugMode = promptDebuggerLaunchInDebugMode;
         }
     }
 }

--- a/CliFx/CliApplication.cs
+++ b/CliFx/CliApplication.cs
@@ -125,8 +125,19 @@ namespace CliFx
                 // Debug mode
                 if (_configuration.IsDebugModeAllowed && input.IsDebugDirectiveSpecified)
                 {
-                    // Ensure debugger is attached and continue
-                    await WaitForDebuggerAsync();
+                    if (_configuration.PromptDebuggerLaunchInDebugMode)
+                    {
+                        // Prompt debugger launcher dialog
+                        if (!Debugger.IsAttached)
+                        {
+                            Debugger.Launch();
+                        }
+                    }
+                    else
+                    {
+                        // Ensure debugger is attached and continue
+                        await WaitForDebuggerAsync();
+                    }
                 }
 
                 // Preview mode

--- a/CliFx/CliApplicationBuilder.cs
+++ b/CliFx/CliApplicationBuilder.cs
@@ -16,6 +16,7 @@ namespace CliFx
         private readonly HashSet<Type> _commandTypes = new HashSet<Type>();
 
         private bool _isDebugModeAllowed = true;
+        private bool _promptDebuggerLaunch = false;
         private bool _isPreviewModeAllowed = true;
         private string? _title;
         private string? _executableName;
@@ -78,9 +79,10 @@ namespace CliFx
         /// <summary>
         /// Specifies whether debug mode (enabled with [debug] directive) is allowed in the application.
         /// </summary>
-        public CliApplicationBuilder AllowDebugMode(bool isAllowed = true)
+        public CliApplicationBuilder AllowDebugMode(bool isAllowed = true, bool promptDebuggerLaunch = false)
         {
             _isDebugModeAllowed = isAllowed;
+            _promptDebuggerLaunch = promptDebuggerLaunch;
             return this;
         }
 
@@ -166,7 +168,7 @@ namespace CliFx
             _typeActivator ??= new DefaultTypeActivator();
 
             var metadata = new ApplicationMetadata(_title, _executableName, _versionText, _description);
-            var configuration = new ApplicationConfiguration(_commandTypes.ToArray(), _isDebugModeAllowed, _isPreviewModeAllowed);
+            var configuration = new ApplicationConfiguration(_commandTypes.ToArray(), _isDebugModeAllowed, _isPreviewModeAllowed, _promptDebuggerLaunch);
 
             return new CliApplication(metadata, configuration, _console, _typeActivator);
         }


### PR DESCRIPTION
Added ability to specify active debugger attachment instead passive.

Fluent builder `AllowDebugMode` method extended with additional `promptDebuggerLaunch : bool` parameter. This will cause `Debugger.Launch()` method execution when application is in debug mode and debug mode is allowed.

Default value is **false** for backward compatibility.