### PR TITLE
Fix application crashes if there are two environment variables with same name, differing only in case

### DIFF
--- a/CliFx.Analyzers/CommandSchemaAnalyzer.cs
+++ b/CliFx.Analyzers/CommandSchemaAnalyzer.cs
@@ -206,7 +206,7 @@ namespace CliFx.Analyzers
             // Duplicate environment variable name
             var duplicateEnvironmentVariableNameOptions = options
                 .Where(p => !string.IsNullOrWhiteSpace(p.EnvironmentVariableName))
-                .GroupBy(p => p.EnvironmentVariableName, StringComparer.OrdinalIgnoreCase)
+                .GroupBy(p => p.EnvironmentVariableName, StringComparer.Ordinal)
                 .Where(g => g.Count() > 1)
                 .SelectMany(g => g.AsEnumerable())
                 .ToArray();

--- a/CliFx.Tests/EnvironmentVariablesSpecs.cs
+++ b/CliFx.Tests/EnvironmentVariablesSpecs.cs
@@ -89,5 +89,27 @@ namespace CliFx.Tests
                 Option = $"foo{Path.PathSeparator}bar"
             });
         }
+        
+        [Fact]
+        public void Environment_variables_pulled_while_respecting_case()
+        {
+            // Arrange
+            const string expected = "foobar";
+            var input = CommandInput.Empty;
+            var envVars = new Dictionary<string, string>
+            {
+                ["ENV_OPT"] = expected,
+                ["env_opt"] = "2"
+            };
+
+            // Act
+            var instance = CommandHelper.ResolveCommand<EnvironmentVariableCommand>(input, envVars);
+
+            // Assert
+            instance.Should().BeEquivalentTo(new EnvironmentVariableCommand
+            {
+                Option = expected
+            });
+        }
     }
 }

--- a/CliFx.Tests/EnvironmentVariablesSpecs.cs
+++ b/CliFx.Tests/EnvironmentVariablesSpecs.cs
@@ -91,7 +91,7 @@ namespace CliFx.Tests
         }
         
         [Fact]
-        public void Environment_variables_pulled_while_respecting_case()
+        public void Option_can_use_a_specific_environment_variable_as_fallback_while_respecting_case()
         {
             // Arrange
             const string expected = "foobar";

--- a/CliFx/CliApplication.cs
+++ b/CliFx/CliApplication.cs
@@ -218,9 +218,11 @@ namespace CliFx
         /// </remarks>
         public async ValueTask<int> RunAsync(IReadOnlyList<string> commandLineArguments)
         {
+            // note: https://docs.microsoft.com/en-us/dotnet/api/system.environment.getenvironmentvariable
+            // Environment variable names are case-sensitive on Linux and macOS but are not case-sensitive on Windows.
             var environmentVariables = Environment.GetEnvironmentVariables()
                 .Cast<DictionaryEntry>()
-                .ToDictionary(e => (string) e.Key, e => (string) e.Value, StringComparer.OrdinalIgnoreCase);
+                .ToDictionary(e => (string) e.Key, e => (string) e.Value, StringComparer.Ordinal);
 
             return await RunAsync(commandLineArguments, environmentVariables);
         }

--- a/CliFx/CliApplication.cs
+++ b/CliFx/CliApplication.cs
@@ -218,8 +218,7 @@ namespace CliFx
         /// </remarks>
         public async ValueTask<int> RunAsync(IReadOnlyList<string> commandLineArguments)
         {
-            // note: https://docs.microsoft.com/en-us/dotnet/api/system.environment.getenvironmentvariable
-            // Environment variable names are case-sensitive on Linux and macOS but are not case-sensitive on Windows.
+            // Environment variable names are case-insensitive on Windows but are case-sensitive on Linux and macOS
             var environmentVariables = Environment.GetEnvironmentVariables()
                 .Cast<DictionaryEntry>()
                 .ToDictionary(e => (string) e.Key, e => (string) e.Value, StringComparer.Ordinal);

--- a/CliFx/Domain/CommandOptionSchema.cs
+++ b/CliFx/Domain/CommandOptionSchema.cs
@@ -45,7 +45,7 @@ namespace CliFx.Domain
 
         public bool MatchesEnvironmentVariableName(string environmentVariableName) =>
             !string.IsNullOrWhiteSpace(EnvironmentVariableName) &&
-            string.Equals(EnvironmentVariableName, environmentVariableName, StringComparison.OrdinalIgnoreCase);
+            string.Equals(EnvironmentVariableName, environmentVariableName, StringComparison.Ordinal);
 
         public string GetUserFacingDisplayString()
         {


### PR DESCRIPTION
## Summary 

This corrects the bug identified in #64.

## Approach

The solution to this was less obvious than I expected when I sat down to build this.

As I saw it, there were a few options here:
* treat env keys as OrdinalIgnoreCase and pull the first value
* treat env keys as OrdinalIgnoreCase and pull the last value
* move to ordinal string comparison for env keys

I then read:

https://docs.microsoft.com/en-us/dotnet/api/system.environment.getenvironmentvariable

which includes: 

    To retrieve all environment variables along with their values, call the GetEnvironmentVariables method. 
    Environment variable names are case-sensitive on Linux and macOS but are not case-sensitive on Windows.

Then attempted to set two environment variables on Windows that only differed by case and did not find a way to do so.

So decided to approach with Ordinal string comparison and submit for discussion.

Going with this approach required a change in `CommandOptionsSchema`

Added a unit test to verify the behaviour.

Happy to iterate if you have a preferred approach.

Fixes #64