### PR TITLE
Add error for non-scalar parameters bound without any values

### DIFF
--- a/CliFx.Tests/ArgumentBindingSpecs.cs
+++ b/CliFx.Tests/ArgumentBindingSpecs.cs
@@ -895,6 +895,31 @@ namespace CliFx.Tests
         }
 
         [Fact]
+        public void Scalar_properties_annotated_as_parameter_requires_input()
+        {
+            // Arrange
+            var input = new CommandInputBuilder()
+                .Build();
+            
+            // Act & assert
+            var ex = Assert.Throws<CliFxException>(() => CommandHelper.ResolveCommand<ParametersCommand>(input));
+            _output.WriteLine(ex.Message);
+        }
+
+        [Fact]
+        public void NonScalar_properties_annotated_as_parameter_requires_input() 
+        {
+            // Arrange
+            var input = new CommandInputBuilder()
+                .AddParameter("foo")
+                .AddParameter("bar")
+                .Build();
+
+            var ex = Assert.Throws<CliFxException>(() => CommandHelper.ResolveCommand<ParametersCommand>(input));
+            _output.WriteLine(ex.Message);
+        }
+
+        [Fact]
         public void Property_annotated_as_parameter_must_always_be_bound_to_some_value()
         {
             // Arrange

--- a/CliFx/Domain/CommandSchema.cs
+++ b/CliFx/Domain/CommandSchema.cs
@@ -103,7 +103,10 @@ namespace CliFx.Domain
 
             if (nonScalarParameter != null)
             {
-                // TODO: Should it verify that at least one value is passed?
+                // Verify that we have at least one value
+                if(!parameterInputs.Skip(scalarParameters.Length).Any())
+                    throw CliFxException.NonScalarParameterNotSet(nonScalarParameter);
+
                 var nonScalarValues = parameterInputs
                     .Skip(scalarParameters.Length)
                     .Select(p => p.Value)

--- a/CliFx/Domain/CommandSchema.cs
+++ b/CliFx/Domain/CommandSchema.cs
@@ -105,7 +105,7 @@ namespace CliFx.Domain
             {
                 // Verify that we have at least one value
                 if(!parameterInputs.Skip(scalarParameters.Length).Any())
-                    throw CliFxException.NonScalarParameterNotSet(nonScalarParameter);
+                    throw CliFxException.ParameterNotSet(nonScalarParameter);
 
                 var nonScalarValues = parameterInputs
                     .Skip(scalarParameters.Length)

--- a/CliFx/Exceptions/CliFxException.cs
+++ b/CliFx/Exceptions/CliFxException.cs
@@ -389,11 +389,5 @@ Unrecognized options provided:
 
             return new CliFxException(message.Trim());
         }
-
-        internal static CliFxException NonScalarParameterNotSet(CommandParameterSchema parameter) 
-        {
-            var message = $@"Missing value for non scalar parameter {parameter.GetUserFacingDisplayString()}.";
-            return new CliFxException(message.Trim());
-        }
     }
 }

--- a/CliFx/Exceptions/CliFxException.cs
+++ b/CliFx/Exceptions/CliFxException.cs
@@ -389,5 +389,11 @@ Unrecognized options provided:
 
             return new CliFxException(message.Trim());
         }
+
+        internal static CliFxException NonScalarParameterNotSet(CommandParameterSchema parameter) 
+        {
+            var message = $@"Missing value for non scalar parameter {parameter.GetUserFacingDisplayString()}.";
+            return new CliFxException(message.Trim());
+        }
     }
 }


### PR DESCRIPTION
closes #65 

It will now be verified that a parameter has at least one value if it's non scalar.