### PR TITLE
Add child command usage in help text

### DIFF
--- a/CliFx/Domain/HelpTextWriter.cs
+++ b/CliFx/Domain/HelpTextWriter.cs
@@ -114,7 +114,7 @@ namespace CliFx.Domain
 
             WriteHeader("Usage");
 
-            WriteCommandUsageLineItem(command);
+            WriteCommandUsageLineItem(command, childCommands.Count > 0);
 
             if (!IsEmpty)
                 WriteVerticalMargin();

--- a/CliFx/Domain/HelpTextWriter.cs
+++ b/CliFx/Domain/HelpTextWriter.cs
@@ -355,7 +355,9 @@ namespace CliFx.Domain
             CommandSchema command,
             IReadOnlyDictionary<CommandArgumentSchema, object?> defaultValues)
         {
-            var childCommands = root.GetChildCommands(command.Name);
+            var commandName = command.Name;
+            var childCommands = root.GetChildCommands(commandName);
+            var descendantCommands = root.GetDescendantCommands(commandName);
 
             _console.ResetColor();
 
@@ -363,22 +365,10 @@ namespace CliFx.Domain
                 WriteApplicationInfo();
 
             WriteCommandDescription(command);
-            WriteCommandUsage(
-                    command, GetUsageCommands(command, root.Commands).ToList());
+            WriteCommandUsage(command, descendantCommands);
             WriteCommandParameters(command);
             WriteCommandOptions(command, defaultValues);
             WriteCommandChildren(command, childCommands);
-
-            static IReadOnlyList<CommandSchema> GetUsageCommands(
-                CommandSchema command, IReadOnlyList<CommandSchema> commands) =>
-                command switch
-                {
-                    { IsDefault: true } => commands,
-                    _ => commands.Where(c =>
-                        c.Name?.StartsWith(
-                            command.Name,
-                            StringComparison.OrdinalIgnoreCase) ?? false).ToList(),
-                };
         }
     }
 

--- a/CliFx/Domain/HelpTextWriter.cs
+++ b/CliFx/Domain/HelpTextWriter.cs
@@ -107,6 +107,16 @@ namespace CliFx.Domain
 
         private void WriteCommandUsage(CommandSchema command, IReadOnlyList<CommandSchema> childCommands)
         {
+            WriteOverviewCommandUsage(command, childCommands);
+            foreach (var childCommand in childCommands)
+            {
+                WriteSubCommandUsage(childCommand);
+            }
+
+        }
+
+        private void WriteOverviewCommandUsage(CommandSchema command, IReadOnlyList<CommandSchema> childCommands)
+        {
             if (!IsEmpty)
                 WriteVerticalMargin();
 
@@ -128,6 +138,57 @@ namespace CliFx.Domain
             {
                 Write(' ');
                 Write(ConsoleColor.Cyan, "[command]");
+            }
+
+            // Parameters
+            foreach (var parameter in command.Parameters)
+            {
+                Write(' ');
+                Write(parameter.IsScalar
+                    ? $"<{parameter.Name}>"
+                    : $"<{parameter.Name}...>"
+                );
+            }
+
+            // Required options
+            foreach (var option in command.Options.Where(o => o.IsRequired))
+            {
+                Write(' ');
+                Write(ConsoleColor.White, !string.IsNullOrWhiteSpace(option.Name)
+                    ? $"--{option.Name}"
+                    : $"-{option.ShortName}"
+                );
+
+                Write(' ');
+                Write(option.IsScalar
+                    ? "<value>"
+                    : "<values...>"
+                );
+            }
+
+            // Options placeholder
+            Write(' ');
+            Write(ConsoleColor.White, "[options]");
+
+            WriteLine();
+        }
+
+        // TODO: refactor: extract common logic between WriteOverviewCommandUsage and WriteSubCommandUsage
+        private void WriteSubCommandUsage(CommandSchema command)
+        {
+            if (!IsEmpty)
+                WriteVerticalMargin();
+
+            // Exe name
+            WriteHorizontalMargin(size: 4);
+            // TODO: determine short form
+            Write("{app}");
+
+            // Command name
+            if (!string.IsNullOrWhiteSpace(command.Name))
+            {
+                Write(' ');
+                Write(ConsoleColor.Cyan, command.Name);
             }
 
             // Parameters
@@ -342,7 +403,7 @@ namespace CliFx.Domain
                 WriteApplicationInfo();
 
             WriteCommandDescription(command);
-            WriteCommandUsage(command, childCommands);
+            WriteCommandUsage(command, root.Commands);
             WriteCommandParameters(command);
             WriteCommandOptions(command, defaultValues);
             WriteCommandChildren(command, childCommands);


### PR DESCRIPTION
Here is a little proof of concept for #11.

Let's determine the next things: 

* **Q1:** Do we always want to show verbose usage every time the help for root command is provided? We could show it only when --help is specified explicitly.
* **Q2:** Do we want to show verbose usage for sub-commands? 
* **Q3:** How can we make usage shorter and more user-friendly in the case when the application executable consists of "dotnet MyProgram.dll"?

**Note,** this is not final implementation. I've created this to communicate ideas and clarify the next steps.

E.g. 
![image](https://user-images.githubusercontent.com/8037439/94862076-22503800-0441-11eb-9e02-2a19c88ccb3e.png)


Closes: #11 