### PR TITLE
Custom value converters

### DIFF
--- a/CliFx.Tests/Commands/CommandWithParameterOfCustomType.cs
+++ b/CliFx.Tests/Commands/CommandWithParameterOfCustomType.cs
@@ -1,0 +1,27 @@
+﻿using CliFx.Attributes;
+using System;
+using System.Threading.Tasks;
+using CliFx.Tests.Commands.Converters;
+using System.Collections.Generic;
+
+namespace CliFx.Tests.Commands
+{
+    public class CustomType
+    {
+        public int SomeValue { get; set; }
+    }
+
+    [Command("cmd")]
+    public class CommandWithParameterOfCustomType : SelfSerializeCommandBase
+    {
+        [CommandOption("prop", Converter = typeof(CustomTypeConverter))]
+        public CustomType MyProperty { get; set; }
+    }
+
+    [Command("cmd")]
+    public class CommandWithEnumerableOfParametersOfCustomType : SelfSerializeCommandBase
+    {
+        [CommandOption("prop", Converter = typeof(CustomTypeConverter))]
+        public List<CustomType> MyProperties { get; set; }
+    }
+}

--- a/CliFx.Tests/Commands/CommandWithParameterOfCustomType.cs
+++ b/CliFx.Tests/Commands/CommandWithParameterOfCustomType.cs
@@ -15,13 +15,13 @@ namespace CliFx.Tests.Commands
     public class CommandWithParameterOfCustomType : SelfSerializeCommandBase
     {
         [CommandOption("prop", Converter = typeof(CustomTypeConverter))]
-        public CustomType MyProperty { get; set; }
+        public CustomType? MyProperty { get; set; }
     }
 
     [Command("cmd")]
     public class CommandWithEnumerableOfParametersOfCustomType : SelfSerializeCommandBase
     {
         [CommandOption("prop", Converter = typeof(CustomTypeConverter))]
-        public List<CustomType> MyProperties { get; set; }
+        public List<CustomType>? MyProperties { get; set; }
     }
 }

--- a/CliFx.Tests/Commands/Converters/CustomTypeConverter.cs
+++ b/CliFx.Tests/Commands/Converters/CustomTypeConverter.cs
@@ -1,8 +1,6 @@
-﻿using CliFx.Domain;
-
-namespace CliFx.Tests.Commands.Converters
+﻿namespace CliFx.Tests.Commands.Converters
 {
-    public class CustomTypeConverter : IConverter
+    public class CustomTypeConverter : IArgumentValueConverter
     {
         public object ConvertFrom(string value) => 
             new CustomType { SomeValue = value.Length };

--- a/CliFx.Tests/Commands/Converters/CustomTypeConverter.cs
+++ b/CliFx.Tests/Commands/Converters/CustomTypeConverter.cs
@@ -1,0 +1,10 @@
+﻿using CliFx.Domain;
+
+namespace CliFx.Tests.Commands.Converters
+{
+    public class CustomTypeConverter : IConverter
+    {
+        public object ConvertFrom(string value) => 
+            new CustomType { SomeValue = value.Length };
+    }
+}

--- a/CliFx/Attributes/CommandOptionAttribute.cs
+++ b/CliFx/Attributes/CommandOptionAttribute.cs
@@ -38,6 +38,11 @@ namespace CliFx.Attributes
         public string? EnvironmentVariableName { get; set; }
 
         /// <summary>
+        /// Type of a converter to use for the option value evaluating.
+        /// </summary>
+        public Type? Converter { get; set; }
+
+        /// <summary>
         /// Initializes an instance of <see cref="CommandOptionAttribute"/>.
         /// </summary>
         private CommandOptionAttribute(string? name, char? shortName)

--- a/CliFx/Attributes/CommandParameterAttribute.cs
+++ b/CliFx/Attributes/CommandParameterAttribute.cs
@@ -27,6 +27,11 @@ namespace CliFx.Attributes
         public string? Description { get; set; }
 
         /// <summary>
+        /// Type of a converter to use for the parameter value evaluating.
+        /// </summary>
+        public Type? Converter { get; set; }
+
+        /// <summary>
         /// Initializes an instance of <see cref="CommandParameterAttribute"/>.
         /// </summary>
         public CommandParameterAttribute(int order)

--- a/CliFx/Domain/CommandOptionSchema.cs
+++ b/CliFx/Domain/CommandOptionSchema.cs
@@ -23,13 +23,15 @@ namespace CliFx.Domain
             char? shortName,
             string? environmentVariableName,
             bool isRequired,
-            string? description)
+            string? description,
+            Type? converter = null)
             : base(property, description)
         {
             Name = name;
             ShortName = shortName;
             EnvironmentVariableName = environmentVariableName;
             IsRequired = isRequired;
+            Converter = converter;
         }
 
         public bool MatchesName(string? name) =>
@@ -97,7 +99,8 @@ namespace CliFx.Domain
                 attribute.ShortName,
                 attribute.EnvironmentVariableName,
                 attribute.IsRequired,
-                attribute.Description
+                attribute.Description,
+                attribute.Converter
             );
         }
     }

--- a/CliFx/Domain/CommandOptionSchema.cs
+++ b/CliFx/Domain/CommandOptionSchema.cs
@@ -25,13 +25,12 @@ namespace CliFx.Domain
             bool isRequired,
             string? description,
             Type? converter = null)
-            : base(property, description)
+            : base(property, description, converter)
         {
             Name = name;
             ShortName = shortName;
             EnvironmentVariableName = environmentVariableName;
             IsRequired = isRequired;
-            Converter = converter;
         }
 
         public bool MatchesName(string? name) =>

--- a/CliFx/Domain/CommandParameterSchema.cs
+++ b/CliFx/Domain/CommandParameterSchema.cs
@@ -13,11 +13,10 @@ namespace CliFx.Domain
         public string Name { get; }
 
         public CommandParameterSchema(PropertyInfo? property, int order, string name, string? description, Type? converter = null)
-            : base(property, description)
+            : base(property, description, converter)
         {
             Order = order;
             Name = name;
-            Converter = converter;
         }
 
         public string GetUserFacingDisplayString()

--- a/CliFx/Domain/CommandParameterSchema.cs
+++ b/CliFx/Domain/CommandParameterSchema.cs
@@ -13,8 +13,12 @@ namespace CliFx.Domain
         public string Name { get; }
 
         public CommandParameterSchema(PropertyInfo? property, int order, string name, string? description, Type? converter = null)
-            : base(property, description) =>
-                (Order, Name, Converter) = (order, name, converter);
+            : base(property, description)
+        {
+            Order = order;
+            Name = name;
+            Converter = converter;
+        }
 
         public string GetUserFacingDisplayString()
         {

--- a/CliFx/Domain/CommandParameterSchema.cs
+++ b/CliFx/Domain/CommandParameterSchema.cs
@@ -1,4 +1,5 @@
-﻿using System.Diagnostics.CodeAnalysis;
+﻿using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using System.Text;
 using CliFx.Attributes;
@@ -11,12 +12,9 @@ namespace CliFx.Domain
 
         public string Name { get; }
 
-        public CommandParameterSchema(PropertyInfo? property, int order, string name, string? description)
-            : base(property, description)
-        {
-            Order = order;
-            Name = name;
-        }
+        public CommandParameterSchema(PropertyInfo? property, int order, string name, string? description, Type? converter = null)
+            : base(property, description) =>
+                (Order, Name, Converter) = (order, name, converter);
 
         public string GetUserFacingDisplayString()
         {
@@ -50,7 +48,8 @@ namespace CliFx.Domain
                 property,
                 attribute.Order,
                 name,
-                attribute.Description
+                attribute.Description,
+                attribute.Converter
             );
         }
     }

--- a/CliFx/Domain/IConverter.cs
+++ b/CliFx/Domain/IConverter.cs
@@ -1,7 +1,13 @@
 ﻿namespace CliFx.Domain
 {
+    /// <summary>
+    /// Used as an interface for implementing custom parameter/option converters.
+    /// </summary>
     public interface IConverter
     {
+        /// <summary>
+        /// Converts an input value to object of required type.
+        /// </summary>
         public object ConvertFrom(string value);
     }
 }

--- a/CliFx/Domain/IConverter.cs
+++ b/CliFx/Domain/IConverter.cs
@@ -1,0 +1,7 @@
+﻿namespace CliFx.Domain
+{
+    public interface IConverter
+    {
+        public object ConvertFrom(string value);
+    }
+}

--- a/CliFx/IArgumentValueConverter.cs
+++ b/CliFx/IArgumentValueConverter.cs
@@ -1,9 +1,9 @@
-﻿namespace CliFx.Domain
+﻿namespace CliFx
 {
     /// <summary>
     /// Used as an interface for implementing custom parameter/option converters.
     /// </summary>
-    public interface IConverter
+    public interface IArgumentValueConverter
     {
         /// <summary>
         /// Converts an input value to object of required type.

--- a/CliFx/Internal/Extensions/TypeExtensions.cs
+++ b/CliFx/Internal/Extensions/TypeExtensions.cs
@@ -56,5 +56,10 @@ namespace CliFx.Internal.Extensions
 
             return array;
         }
+
+        public static T InstanceOf<T>(this Type type) =>
+            type.Implements(typeof(T))
+                ? (T) Activator.CreateInstance(type)
+                : throw new ArgumentException();
     }
 }


### PR DESCRIPTION
`CommandOptionAttribute ` and `CommandParameterAttribute` were extended with a new property - `Type? Converter { get; set; }`, so now user can specify required custom converter's type (that implements `IConverter`) and it will be used to convert a string value to the custom type.

![image](https://user-images.githubusercontent.com/25985600/96043638-f2a92300-0e77-11eb-9e82-d0a8b89316d8.png)

Closes #41