### PR TITLE
Change format for the command section in help text

### DIFF
--- a/CliFx.Tests/HelpTextSpecs.cs
+++ b/CliFx.Tests/HelpTextSpecs.cs
@@ -64,32 +64,6 @@ namespace CliFx.Tests
             _output.WriteLine(stdOut.GetString());
         }
 
-        [Fact]
-        public async Task Help_text_shows_usage_format_which_lists_available_sub_commands()
-        {
-            // Arrange
-            var (console, stdOut, _) = VirtualConsole.CreateBuffered();
-
-            var application = new CliApplicationBuilder()
-                .AddCommand<DefaultCommand>()
-                .AddCommand<NamedCommand>()
-                .AddCommand<NamedSubCommand>()
-                .UseConsole(console)
-                .Build();
-
-            // Act
-            var exitCode = await application.RunAsync(new[] {"--help"});
-
-            // Assert
-            exitCode.Should().Be(0);
-            stdOut.GetString().Should().ContainAll(
-                "Usage",
-                "... named",
-                "... named sub"
-            );
-
-            _output.WriteLine(stdOut.GetString());
-        }
 
         [Fact]
         public async Task Help_text_shows_all_valid_values_for_enum_arguments()

--- a/CliFx.Tests/HelpTextSpecs.cs
+++ b/CliFx.Tests/HelpTextSpecs.cs
@@ -64,6 +64,34 @@ namespace CliFx.Tests
             _output.WriteLine(stdOut.GetString());
         }
 
+        [Fact]
+        public async Task Help_text_shows_commands_list_with_description_and_usage_info()
+        {
+            // Arrange
+            var (console, stdOut, _) = VirtualConsole.CreateBuffered();
+
+            var application = new CliApplicationBuilder()
+                .AddCommand<DefaultCommand>()
+                .AddCommand<NamedCommand>()
+                .AddCommand<NamedSubCommand>()
+                .UseConsole(console)
+                .Build();
+
+            // Act
+            var exitCode = await application.RunAsync(new[] { "--help" });
+
+            // Assert
+            exitCode.Should().Be(0);
+            stdOut.GetString().Should().ContainAll(
+                "Commands",
+                "Named command description",
+                "named [options]",
+                "Named sub command description",
+                "named sub [options]"
+            );
+
+            _output.WriteLine(stdOut.GetString());
+        }
 
         [Fact]
         public async Task Help_text_shows_all_valid_values_for_enum_arguments()

--- a/CliFx/Domain/HelpTextWriter.cs
+++ b/CliFx/Domain/HelpTextWriter.cs
@@ -318,7 +318,6 @@ namespace CliFx.Domain
             }
 
             // Child command help tip
-            WriteVerticalMargin();
             Write("You can run `");
             Write(_metadata.ExecutableName);
 

--- a/CliFx/Domain/HelpTextWriter.cs
+++ b/CliFx/Domain/HelpTextWriter.cs
@@ -302,14 +302,15 @@ namespace CliFx.Domain
                     : descendantCommand.Name!;
 
                 // Description
-                WriteHorizontalMargin();
+                
                 if (!string.IsNullOrWhiteSpace(descendantCommand.Description))
                 {
+                    WriteHorizontalMargin();
                     Write(descendantCommand.Description);
+                    WriteVerticalMargin();
                 }
 
                 // Name
-                WriteVerticalMargin();
                 WriteHorizontalMargin(4);
                 WriteCommandUsageLineItem(descendantCommand, false);
 

--- a/CliFx/Domain/HelpTextWriter.cs
+++ b/CliFx/Domain/HelpTextWriter.cs
@@ -169,19 +169,6 @@ namespace CliFx.Domain
 
             // Current command usage
             WriteCommandUsageLineItem(command, childCommands.Any());
-
-            // Sub commands usage
-            if (childCommands.Any())
-            {
-                WriteVerticalMargin();
-
-                foreach (var childCommand in childCommands)
-                {
-                    WriteHorizontalMargin();
-                    Write("... ");
-                    WriteCommandUsageLineItem(childCommand, false);
-                }
-            }
         }
 
         private void WriteCommandParameters(CommandSchema command)
@@ -298,9 +285,9 @@ namespace CliFx.Domain
 
         private void WriteCommandChildren(
             CommandSchema command,
-            IReadOnlyList<CommandSchema> childCommands)
+            IReadOnlyList<CommandSchema> descendantCommands)
         {
-            if (!childCommands.Any())
+            if (!descendantCommands.Any())
                 return;
 
             if (!IsEmpty)
@@ -308,22 +295,23 @@ namespace CliFx.Domain
 
             WriteHeader("Commands");
 
-            foreach (var childCommand in childCommands)
+            foreach (var descendantCommand in descendantCommands)
             {
                 var relativeCommandName = !string.IsNullOrWhiteSpace(command.Name)
-                    ? childCommand.Name!.Substring(command.Name.Length).Trim()
-                    : childCommand.Name!;
-
-                // Name
-                WriteHorizontalMargin();
-                Write(ConsoleColor.Cyan, relativeCommandName);
+                    ? descendantCommand.Name!.Substring(command.Name.Length).Trim()
+                    : descendantCommand.Name!;
 
                 // Description
-                if (!string.IsNullOrWhiteSpace(childCommand.Description))
+                WriteHorizontalMargin();
+                if (!string.IsNullOrWhiteSpace(descendantCommand.Description))
                 {
-                    WriteColumnMargin();
-                    Write(childCommand.Description);
+                    Write(descendantCommand.Description);
                 }
+
+                // Name
+                WriteVerticalMargin();
+                WriteHorizontalMargin(4);
+                WriteCommandUsageLineItem(descendantCommand, false);
 
                 WriteLine();
             }
@@ -356,7 +344,6 @@ namespace CliFx.Domain
             IReadOnlyDictionary<CommandArgumentSchema, object?> defaultValues)
         {
             var commandName = command.Name;
-            var childCommands = root.GetChildCommands(commandName);
             var descendantCommands = root.GetDescendantCommands(commandName);
 
             _console.ResetColor();
@@ -368,7 +355,7 @@ namespace CliFx.Domain
             WriteCommandUsage(command, descendantCommands);
             WriteCommandParameters(command);
             WriteCommandOptions(command, defaultValues);
-            WriteCommandChildren(command, childCommands);
+            WriteCommandChildren(command, descendantCommands);
         }
     }
 


### PR DESCRIPTION
BREAKING CHANGE: Removed test Help_text_shows_usage_format_which_lists_available_sub_commands, since usage will not longer show the subcommands

Closes #82