### PR TITLE
Allow specifying command options without a name

### DIFF
--- a/CliFx.Analyzers.Tests/CommandSchemaAnalyzerTests.cs
+++ b/CliFx.Analyzers.Tests/CommandSchemaAnalyzerTests.cs
@@ -518,25 +518,6 @@ public class MyCommand : ICommand
             yield return new object[]
             {
                 new AnalyzerTestCase(
-                    "Option with an empty name",
-                    DiagnosticDescriptors.CliFx0041,
-
-                    // language=cs
-                    @"
-[Command]
-public class MyCommand : ICommand
-{
-    [CommandOption("""")]
-    public string Option { get; set; }
-
-    public ValueTask ExecuteAsync(IConsole console) => default;
-}"
-                )
-            };
-
-            yield return new object[]
-            {
-                new AnalyzerTestCase(
                     "Option with a name which is too short",
                     DiagnosticDescriptors.CliFx0042,
 
@@ -547,6 +528,25 @@ public class MyCommand : ICommand
 {
     [CommandOption(""a"")]
     public string Option { get; set; }
+
+    public ValueTask ExecuteAsync(IConsole console) => default;
+}"
+                )
+            };
+
+            yield return new object[]
+            {
+                new AnalyzerTestCase(
+                    "Option with a generated name which is too short",
+                    DiagnosticDescriptors.CliFx0042,
+
+                    // language=cs
+                    @"
+[Command]
+public class MyCommand : ICommand
+{
+    [CommandOption]
+    public string A { get; set; }
 
     public ValueTask ExecuteAsync(IConsole console) => default;
 }"

--- a/CliFx.Analyzers/CommandSchemaAnalyzer.cs
+++ b/CliFx.Analyzers/CommandSchemaAnalyzer.cs
@@ -20,7 +20,6 @@ namespace CliFx.Analyzers
             DiagnosticDescriptors.CliFx0024,
             DiagnosticDescriptors.CliFx0025,
             DiagnosticDescriptors.CliFx0026,
-            DiagnosticDescriptors.CliFx0041,
             DiagnosticDescriptors.CliFx0042,
             DiagnosticDescriptors.CliFx0043,
             DiagnosticDescriptors.CliFx0044,
@@ -225,21 +224,20 @@ namespace CliFx.Analyzers
                 })
                 .ToArray();
 
-            // No name
-            var noNameOptions = options
-                .Where(o => string.IsNullOrWhiteSpace(o.Name) && o.ShortName == null)
-                .ToArray();
-
-            foreach (var option in noNameOptions)
-            {
-                context.ReportDiagnostic(Diagnostic.Create(
-                    DiagnosticDescriptors.CliFx0041, option.Property.Locations.First()
-                ));
-            }
-
             // Too short name
             var invalidNameLengthOptions = options
-                .Where(o => !string.IsNullOrWhiteSpace(o.Name) && o.Name.Length <= 1)
+                .Where(o => {
+
+                    // Option has an explicit name and it is too short
+                    if (!string.IsNullOrWhiteSpace(o.Name) && o.Name.Length <= 1)
+                        return true;
+
+                    // Option doesn't have an explicit name or short name and the resulting generated name would be too short
+                    if (string.IsNullOrEmpty(o.Name) && !o.ShortName.HasValue && o.Property.Name.Length >= 1)
+                        return true;
+
+                    return false;
+                })
                 .ToArray();
 
             foreach (var option in invalidNameLengthOptions)

--- a/CliFx.Analyzers/DiagnosticDescriptors.cs
+++ b/CliFx.Analyzers/DiagnosticDescriptors.cs
@@ -60,13 +60,6 @@ namespace CliFx.Analyzers
                 "Usage", DiagnosticSeverity.Error, true
             );
 
-        public static readonly DiagnosticDescriptor CliFx0041 =
-            new(nameof(CliFx0041),
-                "Option must have a name or short name specified",
-                "Option must have a name or short name specified",
-                "Usage", DiagnosticSeverity.Error, true
-            );
-
         public static readonly DiagnosticDescriptor CliFx0042 =
             new(nameof(CliFx0042),
                 "Option name must be at least 2 characters long",

--- a/CliFx.Tests/ApplicationSpecs.cs
+++ b/CliFx.Tests/ApplicationSpecs.cs
@@ -273,26 +273,6 @@ namespace CliFx.Tests
         }
 
         [Fact]
-        public async Task Command_options_must_have_names_that_are_not_empty()
-        {
-            var (console, _, stdErr) = VirtualConsole.CreateBuffered();
-
-            var application = new CliApplicationBuilder()
-                .AddCommand<EmptyOptionNameCommand>()
-                .UseConsole(console)
-                .Build();
-
-            // Act
-            var exitCode = await application.RunAsync(Array.Empty<string>());
-
-            // Assert
-            exitCode.Should().NotBe(0);
-            stdErr.GetString().Should().NotBeNullOrWhiteSpace();
-
-            _output.WriteLine(stdErr.GetString());
-        }
-
-        [Fact]
         public async Task Command_options_must_have_names_that_are_longer_than_one_character()
         {
             var (console, _, stdErr) = VirtualConsole.CreateBuffered();

--- a/CliFx.Tests/ArgumentBindingSpecs.cs
+++ b/CliFx.Tests/ArgumentBindingSpecs.cs
@@ -114,6 +114,31 @@ namespace CliFx.Tests
         }
 
         [Fact]
+        public async Task Property_annotated_as_an_option_without_especifying_a_name_must_be_set_when_using_the_generated_name()
+        {
+            // Arrange
+            var (console, stdOut, _) = VirtualConsole.CreateBuffered();
+
+            var application = new CliApplicationBuilder()
+                .AddCommand<WithGeneratedOptionNamesCommand>()
+                .UseConsole(console)
+                .Build();
+
+            // Act
+            var exitCode = await application.RunAsync(new[]
+            {
+                "cmd", "--option", "foo", "--another-option", "bar"
+            });
+
+            var commandInstance = stdOut.GetString().DeserializeJson<WithGeneratedOptionNamesCommand>();
+
+            // Assert
+            exitCode.Should().Be(0);
+            commandInstance.Option.Should().Be("foo");
+            commandInstance.AnotherOption.Should().Be("bar");
+        }
+
+        [Fact]
         public async Task Property_annotated_as_parameter_is_bound_directly_from_argument_value_according_to_the_order()
         {
             // Arrange

--- a/CliFx.Tests/Commands/WithGeneratedOptionNamesCommand.cs
+++ b/CliFx.Tests/Commands/WithGeneratedOptionNamesCommand.cs
@@ -1,0 +1,17 @@
+﻿using CliFx.Attributes;
+
+namespace CliFx.Tests.Commands
+{
+    [Command("cmd")]
+    public class WithGeneratedOptionNamesCommand : SelfSerializeCommandBase
+    {
+        [CommandOption(IsRequired = true)]
+        public string? Option { get; set; }
+
+        [CommandOption]
+        public string? AnotherOption { get; set; }
+
+        [CommandOption('n')]
+        public string? NonGenerated { get; set; }
+    }
+}

--- a/CliFx.Tests/HelpTextSpecs.cs
+++ b/CliFx.Tests/HelpTextSpecs.cs
@@ -176,5 +176,32 @@ namespace CliFx.Tests
 
             _output.WriteLine(stdOut.GetString());
         }
+
+        [Fact]
+        public async Task Help_text_shows_generated_command_oiption_names_when_option_name_isnt_provided()
+        {
+            // Arrange
+            var (console, stdOut, _) = VirtualConsole.CreateBuffered();
+
+            var application = new CliApplicationBuilder()
+                .AddCommand<WithGeneratedOptionNamesCommand>()
+                .UseConsole(console)
+                .Build();
+
+            // Act
+            var exitCode = await application.RunAsync(new[] { "cmd", "--help" });
+
+            // Assert
+            exitCode.Should().Be(0);
+            stdOut.GetString().Should().ContainAll(
+                "--option <value>",
+                "Options",
+                "--option",
+                "--another-option",
+                "-n"
+            );
+
+            _output.WriteLine(stdOut.GetString());
+        }
     }
 }

--- a/CliFx/Attributes/CommandOptionAttribute.cs
+++ b/CliFx/Attributes/CommandOptionAttribute.cs
@@ -64,5 +64,13 @@ namespace CliFx.Attributes
             : this(null, (char?) shortName)
         {
         }
+
+        /// <summary>
+        /// Initializes an instance of <see cref="CommandOptionAttribute"/>.
+        /// </summary>
+        public CommandOptionAttribute()
+            : this(null, null)
+        {
+        }
     }
 }

--- a/CliFx/Domain/CommandOptionSchema.cs
+++ b/CliFx/Domain/CommandOptionSchema.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Reflection;
 using System.Text;
 using CliFx.Attributes;
+using CliFx.Internal.Extensions;
 
 namespace CliFx.Domain
 {
@@ -92,6 +93,10 @@ namespace CliFx.Domain
 
             // The user may mistakenly specify dashes, thinking it's required, so trim them
             var name = attribute.Name?.TrimStart('-');
+
+            // If neither command option's name nor short name are provided generate a regular name based on property's name
+            if (string.IsNullOrEmpty(name) && !attribute.ShortName.HasValue)
+                name = property.Name.PascalToKebabCase();
 
             return new CommandOptionSchema(
                 property,

--- a/CliFx/Internal/Extensions/StringExtensions.cs
+++ b/CliFx/Internal/Extensions/StringExtensions.cs
@@ -27,5 +27,23 @@ namespace CliFx.Internal.Extensions
             obj is IFormattable formattable
                 ? formattable.ToString(format, formatProvider)
                 : obj.ToString();
+
+        public static string PascalToKebabCase(this string str)
+        {
+            if (string.IsNullOrEmpty(str))
+                return str;
+
+            var sb = new StringBuilder();
+            var chars = str.ToCharArray();
+            for (int i = 0; i < chars.Length; ++i)
+            {
+                if (i > 0 && char.IsUpper(chars[i]))
+                    sb.Append('-');
+
+                sb.Append(char.ToLower(chars[i]));
+            }
+
+            return sb.ToString();
+        }
     }
 }


### PR DESCRIPTION
Allows command options to provide neither a name nor a short name so a name will be generated by turning the property name to kebab case. Short names are not generated. If a short name has been provided no long name is generated.

Command options now can exists without an explicit name so one analyzer doesn't apply anymore. Also, the analyzer have been updated in such a way that a command option that would generate a name from the property that is too short will be marked as an error so we still avoid having option names shorter than two characters.

Tests updated.

Closes #84 