### PR TITLE
Show choices on non-scalar enum parameters and options

### DIFF
--- a/CliFx/Schema/BindablePropertyDescriptor.cs
+++ b/CliFx/Schema/BindablePropertyDescriptor.cs
@@ -21,7 +21,17 @@ namespace CliFx.Schema
 
         public IReadOnlyList<object?> GetValidValues()
         {
-            var underlyingType = Type.TryGetNullableUnderlyingType() ?? Type;
+            Type typeToCheck = Type;
+            foreach (var inf in typeToCheck.GetInterfaces())
+            {
+                if (inf.IsGenericType && inf.GetGenericTypeDefinition() == typeof(IEnumerable<>))
+                {
+                    typeToCheck = inf.GenericTypeArguments[0];
+                    break;
+                }
+            }
+
+            var underlyingType = typeToCheck.TryGetNullableUnderlyingType() ?? typeToCheck;
 
             // We can only get valid values for enums
             if (underlyingType.IsEnum)


### PR DESCRIPTION
Functions for any collection type that implements `IList<>`.

Relates to issue #18 and expands on functionality provided in PR #53