### PR TITLE
Fix ordering of parameters within command help usage

### DIFF
--- a/CliFx.Tests/Utils/DynamicCommandBuilder.cs
+++ b/CliFx.Tests/Utils/DynamicCommandBuilder.cs
@@ -106,13 +106,13 @@ internal static class DynamicCommandBuilder
         // Return all defined commands
         var commandTypes = generatedAssembly
             .GetTypes()
-            .Where(t => t.IsAssignableTo(typeof(ICommand)))
+            .Where(t => t.IsAssignableTo(typeof(ICommand)) && !t.IsAbstract)
             .ToArray();
 
         if (commandTypes.Length <= 0)
         {
             throw new InvalidOperationException(
-                "There are no command definitions in the provide source code."
+                "There are no command definitions in the provided source code."
             );
         }
 
@@ -126,7 +126,7 @@ internal static class DynamicCommandBuilder
         if (commandTypes.Count > 1)
         {
             throw new InvalidOperationException(
-                "There are more than one command definitions in the provide source code."
+                "There are more than one command definitions in the provided source code."
             );
         }
 

--- a/CliFx/Schema/CommandSchema.cs
+++ b/CliFx/Schema/CommandSchema.cs
@@ -90,6 +90,7 @@ internal partial class CommandSchema
         var parameterSchemas = type.GetProperties()
             .Select(ParameterSchema.TryResolve)
             .Where(p => p is not null)
+            .OrderBy(p => p!.Order)
             .ToArray();
 
         var optionSchemas = type.GetProperties()


### PR DESCRIPTION
In certain cases, such as when defining parameters within base command classes that other command classes inherit from, the command help documentation may list parameters in an incorrect order.

This PR ensures that parameters are always listed based on their `Order` property when displaying the help documentation for a command.

Closes #117 