### PR TITLE
Add multiple inheritance support through interfaces

### DIFF
--- a/CliFx/Schema/CommandSchema.cs
+++ b/CliFx/Schema/CommandSchema.cs
@@ -89,8 +89,7 @@ internal partial class CommandSchema
         
         // Include interface members for multiple inheritance
         // If interface inherits from ICommand, it will be included
-        var iType = typeof(ICommand);
-        var interfaces = type.GetInterfaces().Where(i => i != iType && iType.IsAssignableFrom(i) );
+        var interfaces = type.GetInterfaces().Where(i => i != typeof(ICommand) && typeof(ICommand).IsAssignableFrom(i) );
         var properties = type.GetProperties().Concat(interfaces.SelectMany(i => i.GetProperties())).ToArray();
       
         var parameterSchemas = properties

--- a/CliFx/Schema/CommandSchema.cs
+++ b/CliFx/Schema/CommandSchema.cs
@@ -86,9 +86,13 @@ internal partial class CommandSchema
         var implicitOptionSchemas = string.IsNullOrWhiteSpace(name)
             ? new[] {OptionSchema.HelpOption, OptionSchema.VersionOption}
             : new[] {OptionSchema.HelpOption};
-
-        var properties = type.GetProperties();
-
+        
+        // Include interface members for multiple inheritance
+        // If interface inherits from ICommand, it will be included
+        var iType = typeof(ICommand);
+        var interfaces = type.GetInterfaces().Where(i => i != iType && iType.IsAssignableFrom(i) );
+        var properties = type.GetProperties().Concat(interfaces.SelectMany(i => i.GetProperties())).ToArray();
+      
         var parameterSchemas = properties
             .Select(ParameterSchema.TryResolve)
             .WhereNotNull()

--- a/CliFx/Schema/CommandSchema.cs
+++ b/CliFx/Schema/CommandSchema.cs
@@ -87,12 +87,14 @@ internal partial class CommandSchema
             ? new[] {OptionSchema.HelpOption, OptionSchema.VersionOption}
             : new[] {OptionSchema.HelpOption};
 
-        var parameterSchemas = type.GetProperties()
+        var properties = type.GetProperties();
+
+        var parameterSchemas = properties
             .Select(ParameterSchema.TryResolve)
             .WhereNotNull()
             .ToArray();
 
-        var optionSchemas = type.GetProperties()
+        var optionSchemas = properties
             .Select(OptionSchema.TryResolve)
             .WhereNotNull()
             .Concat(implicitOptionSchemas)


### PR DESCRIPTION
This PR unluck multiple inheritance using interfaces (c# 8 feature) for `CommandParameter` and `CommandOption`.
why?
I was looking for a solution to define a few global options, In #58 You had a [suggestion](https://github.com/Tyrrrz/CliFx/issues/58#issuecomment-639489975) about using interfaces for multiple inheritance! that was an amazing suggestion 😲 but unfortunately, clifx did not support that 😟. This PR solves that issue.

Note(optional):
If you have LinqPad check out the attached file, this is a simple real-world example.

Related to #58
[MultipleInheritance.zip](https://github.com/Tyrrrz/CliFx/files/7819918/MultipleInheritance.zip)


