### PR TITLE
Sort commands by name in help text

### DIFF
--- a/CliFx/CliApplicationBuilder.cs
+++ b/CliFx/CliApplicationBuilder.cs
@@ -63,7 +63,9 @@ public partial class CliApplicationBuilder
     /// </remarks>
     public CliApplicationBuilder AddCommandsFrom(Assembly commandAssembly)
     {
-        foreach (var commandType in commandAssembly.ExportedTypes.Where(CommandSchema.IsCommandType))
+        foreach (var commandType in commandAssembly.ExportedTypes
+            .Where(CommandSchema.IsCommandType)
+            .OrderBy(a => a.Name))
             AddCommand(commandType);
 
         return this;

--- a/CliFx/CliApplicationBuilder.cs
+++ b/CliFx/CliApplicationBuilder.cs
@@ -63,9 +63,7 @@ public partial class CliApplicationBuilder
     /// </remarks>
     public CliApplicationBuilder AddCommandsFrom(Assembly commandAssembly)
     {
-        foreach (var commandType in commandAssembly.ExportedTypes
-            .Where(CommandSchema.IsCommandType)
-            .OrderBy(a => a.Name))
+        foreach (var commandType in commandAssembly.ExportedTypes.Where(CommandSchema.IsCommandType))
             AddCommand(commandType);
 
         return this;

--- a/CliFx/Formatting/HelpConsoleFormatter.cs
+++ b/CliFx/Formatting/HelpConsoleFormatter.cs
@@ -368,7 +368,7 @@ internal class HelpConsoleFormatter : ConsoleFormatter
         var childCommandSchemas = _context
             .ApplicationSchema
             .GetChildCommands(_context.CommandSchema.Name)
-            .OrderBy(a => a.Name);
+            .OrderBy(a => a.Name, StringComparer.Ordinal);
 
         if (!childCommandSchemas.Any())
             return;

--- a/CliFx/Formatting/HelpConsoleFormatter.cs
+++ b/CliFx/Formatting/HelpConsoleFormatter.cs
@@ -367,7 +367,8 @@ internal class HelpConsoleFormatter : ConsoleFormatter
     {
         var childCommandSchemas = _context
             .ApplicationSchema
-            .GetChildCommands(_context.CommandSchema.Name);
+            .GetChildCommands(_context.CommandSchema.Name)
+            .OrderBy(a => a.Name);
 
         if (!childCommandSchemas.Any())
             return;


### PR DESCRIPTION
When you have lots of commands, having an alphabetical list is easier to read through, so you can find what you are looking for faster.

Discussed and Closes [#133](https://github.com/Tyrrrz/CliFx/discussions/133)
