### PR TITLE
Expect same environment variables with different case on Windows

### DIFF
--- a/CliFx/CliApplication.cs
+++ b/CliFx/CliApplication.cs
@@ -229,11 +229,7 @@ public class CliApplication
             commandLineArguments,
             Environment
                 .GetEnvironmentVariables()
-                .ToDictionary<string, string>(
-                    RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
-                        ? StringComparer.OrdinalIgnoreCase
-                        : StringComparer.Ordinal
-                )
+                .ToDictionary<string, string>(StringComparer.Ordinal)
         );
 
     /// <summary>


### PR DESCRIPTION
Previously, the code differentiated between Windows and other operating systems by using StringComparer.OrdinalIgnoreCase for Windows and StringComparer.Ordinal for others. This led to conflicts on Windows when environment variables differed only by case (e.g., `HOME` vs `home`).

The change simplifies the approach by using `StringComparer.Ordinal` for all platforms, ensuring consistent and case-sensitive handling of environment variables.